### PR TITLE
feat: remove unused snapshots in snapshot file

### DIFF
--- a/.githooks.ini
+++ b/.githooks.ini
@@ -1,2 +1,3 @@
 [pre-commit]
 command = inv lint
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ if __name__ == "__main__":
         use_scm_version={"write_to": "version.txt"},
         package_dir={"": "src"},
         packages=["syrupy"],
-        py_modules=["syrupy"],
         zip_safe=False,
         install_requires=[],
         setup_requires=["setuptools_scm"],

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -52,8 +52,11 @@ def snapshot(request):
         classname=request.cls.__name__ if request.cls else None,
         methodname=request.function.__name__ if request.function else None,
         nodename=getattr(request.node, "name", ""),
-        testname=getattr(request.node, "name", "")
-        or (request.function.__name__ if request.function else None),
+        testname=getattr(
+            request.node,
+            "name",
+            request.function.__name__ if request.function else None,
+        ),
     )
     return SnapshotAssertion(
         update_snapshots=request.config.option.update_snapshots,

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -75,8 +75,8 @@ class SnapshotAssertion:
 
         return []
 
-    def _file_hook(self, filepath):
-        self._session.add_visited_snapshots({filepath: {}})
+    def _file_hook(self, filepath, snapshot_name):
+        self._session.add_visited_snapshots({filepath: {snapshot_name}})
 
     def __repr__(self) -> str:
         return f"<SnapshotAssertion ({self.num_executions})>"

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -46,7 +46,7 @@ class SnapshotAssertion:
         return self._serializer
 
     @property
-    def count(self) -> int:
+    def num_executions(self) -> int:
         return int(self._executions)
 
     def with_class(
@@ -88,10 +88,10 @@ class SnapshotAssertion:
         return self._assert(other)
 
     def _assert(self, data) -> bool:
-        executions = self.count
+        executions = self.num_executions
         self._executions += 1
 
-        self._session.register_assertion(self)
+        self._session.register_assertion(self, executions)
 
         if self._update_snapshots:
             serialized_data = self.serializer.encode(data)

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -1,12 +1,12 @@
 import traceback
 import pytest
 import os
-from typing import Callable, List, Optional, Any
+from typing import Any, Callable, List, Optional, Type
 
 from .exceptions import SnapshotDoesNotExist
 
-from .io import SnapshotIO, SnapshotIOClass
-from .serializer import SnapshotSerializer, SnapshotSerializerClass
+from .io import SnapshotIO
+from .serializer import SnapshotSerializer
 from .location import TestLocation
 
 
@@ -15,8 +15,8 @@ class SnapshotAssertion:
         self,
         *,
         update_snapshots: bool,
-        io_class: SnapshotIOClass,
-        serializer_class: SnapshotSerializerClass,
+        io_class: Type[SnapshotIO],
+        serializer_class: Type[SnapshotSerializer],
         test_location: TestLocation,
         session,
     ):
@@ -51,8 +51,8 @@ class SnapshotAssertion:
 
     def with_class(
         self,
-        io_class: SnapshotIOClass = None,
-        serializer_class: SnapshotSerializerClass = None,
+        io_class: Type[SnapshotIO] = None,
+        serializer_class: Type[SnapshotSerializer] = None,
     ):
         return self.__class__(
             update_snapshots=self._update_snapshots,

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import os
 import yaml
@@ -6,6 +6,7 @@ import yaml
 from .constants import SNAPSHOT_DIRNAME
 from .exceptions import SnapshotDoesNotExist
 from .location import TestLocation
+from .types import Albums
 
 
 class SnapshotIO:
@@ -13,33 +14,65 @@ class SnapshotIO:
         self._test_location = test_location
         self._file_hook = file_hook
 
-    def pre_write(self, data: Any, index: int = 0):
-        self.ensure_snapshot_dir(index)
+    @property
+    def test_location(self):
+        return self._test_location
 
-    def write(self, data: Any, index: int = 0):
-        snapshot_name = self.get_snapshot_name(index)
-        snapshots = self._load_documents(index)
-        snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
-        snapshots[snapshot_name]["data"] = data
-        with open(self.get_filepath(index), "w") as f:
-            yaml.safe_dump(snapshots, f)
-
-    def post_write(self, data: Any, index: int = 0):
-        self._file_hook(self.get_filepath(index))
+    @property
+    def dirname(self) -> str:
+        test_dirname = os.path.dirname(self.test_location.filename)
+        snapshot_dir = self._get_snapshot_dirname()
+        if snapshot_dir is not None:
+            return os.path.join(test_dirname, SNAPSHOT_DIRNAME, snapshot_dir)
+        return os.path.join(test_dirname, SNAPSHOT_DIRNAME)
 
     def pre_read(self, index: int = 0):
         pass
 
     def read(self, index: int = 0) -> Any:
+        snapshot_file = self.get_filepath(index)
         snapshot_name = self.get_snapshot_name(index)
-        snapshots = self._load_documents(index)
-        snapshot = snapshots.get(snapshot_name, None)
+        snapshot = self._read_snapshot_from_file(snapshot_file, snapshot_name)
         if snapshot is None:
             raise SnapshotDoesNotExist()
-        return snapshot["data"]
+        return snapshot
 
     def post_read(self, index: int = 0):
         self._file_hook(self.get_filepath(index))
+
+    def pre_write(self, data: Any, index: int = 0):
+        try:
+            os.makedirs(os.path.dirname(self.get_filepath(index)))
+        except FileExistsError:
+            pass
+
+    def write(self, data: Any, index: int = 0):
+        snapshot_file = self.get_filepath(index)
+        snapshot_name = self.get_snapshot_name(index)
+        self._write_snapshot_or_remove_file(snapshot_file, snapshot_name, data)
+
+    def post_write(self, data: Any, index: int = 0):
+        self._file_hook(self.get_filepath(index))
+
+    def read_snapshot(self, index: int) -> Any:
+        try:
+            self.pre_read(index=index)
+            return self.read(index=index)
+        finally:
+            self.post_read(index=index)
+
+    def create_or_update_snapshot(self, serialized_data: Any, index: int):
+        self.pre_write(serialized_data, index=index)
+        self.write(serialized_data, index=index)
+        self.post_write(serialized_data, index=index)
+
+    def delete_snapshot(self, snapshot_file: str, snapshot_name: str):
+        self._write_snapshot_or_remove_file(snapshot_file, snapshot_name, None)
+
+    def discover_snapshots(self, index: int = 0) -> Albums:
+        filepath = self.get_filepath(index)
+        snapshots = self._read_file(filepath)
+        return {filepath: set(snapshots.keys())}
 
     def get_snapshot_name(self, index: int = 0) -> str:
         index_suffix = f".{index}" if index > 0 else ""
@@ -49,37 +82,46 @@ class SnapshotIO:
             return f"{self._test_location.classname}.{methodname}{index_suffix}"
         return f"{methodname}{index_suffix}"
 
-    def get_snapshot_dirname(self) -> Optional[str]:
-        return None
-
     def get_filepath(self, index: int) -> str:
         basename = self.get_file_basename(index=index)
-        return os.path.join(self._get_dirname(), basename)
+        return os.path.join(self.dirname, basename)
 
     def get_file_basename(self, index: int) -> str:
         return f"{os.path.basename(self._test_location.filename)[: -len('.py')]}.yaml"
 
-    def ensure_snapshot_dir(self, index: int):
-        try:
-            os.makedirs(os.path.dirname(self.get_filepath(index)))
-        except FileExistsError:
-            pass
+    def _get_snapshot_dirname(self) -> Optional[str]:
+        return None
 
-    @property
-    def test_location(self):
-        return self._test_location
+    def _read_snapshot_from_file(self, snapshot_file: str, snapshot_name: str) -> Any:
+        snapshots = self._read_file(snapshot_file)
+        return snapshots.get(snapshot_name, {}).get("data", None)
 
-    def _load_documents(self, index: int) -> dict:
+    def _read_file(self, filepath: str) -> Any:
         try:
-            with open(self.get_filepath(index), "r") as f:
+            with open(filepath, "r") as f:
                 return yaml.safe_load(f) or {}
         except FileNotFoundError:
             pass
         return {}
 
-    def _get_dirname(self) -> str:
-        test_dirname = os.path.dirname(self._test_location.filename)
-        snapshot_dir = self.get_snapshot_dirname()
-        if snapshot_dir is not None:
-            return os.path.join(test_dirname, SNAPSHOT_DIRNAME, snapshot_dir)
-        return os.path.join(test_dirname, SNAPSHOT_DIRNAME)
+    def _write_snapshot_or_remove_file(
+        self, snapshot_file: str, snapshot_name: str, data: Any
+    ):
+        snapshots = self._read_file(snapshot_file)
+        if data:
+            snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
+            snapshots[snapshot_name]["data"] = data
+        elif snapshot_name in snapshots:
+            del snapshots[snapshot_name]
+
+        if snapshots:
+            self._write_file(snapshot_file, snapshots)
+        else:
+            os.remove(snapshot_file)
+
+    def _write_file(self, filepath: str, data: Any):
+        with open(filepath, "w") as f:
+            yaml.safe_dump(data, f)
+
+
+SnapshotIOClass = Callable[..., SnapshotIO]

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -6,7 +6,7 @@ import yaml
 from .constants import SNAPSHOT_DIRNAME
 from .exceptions import SnapshotDoesNotExist
 from .location import TestLocation
-from .types import Albums
+from .types import SnapshotFiles
 
 
 class SnapshotIO:
@@ -69,7 +69,7 @@ class SnapshotIO:
     def delete_snapshot(self, snapshot_file: str, snapshot_name: str):
         self._write_snapshot_or_remove_file(snapshot_file, snapshot_name, None)
 
-    def discover_snapshots(self, index: int = 0) -> Albums:
+    def discover_snapshots(self, index: int = 0) -> SnapshotFiles:
         filepath = self.get_filepath(index)
         snapshots = self._read_file(filepath)
         return {filepath: set(snapshots.keys())}

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -149,11 +149,11 @@ class SnapshotIO:
         If the snapshot file will be empty remove the entire file.
         """
         snapshots = self._read_file(snapshot_file)
-        if data is None:
+        if data is None and snapshot_name in snapshots:
+            del snapshots[snapshot_name]
+        else:
             snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
             snapshots[snapshot_name]["data"] = data
-        elif snapshot_name in snapshots:
-            del snapshots[snapshot_name]
 
         if snapshots:
             self._write_file(snapshot_file, snapshots)

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -167,6 +167,3 @@ class SnapshotIO:
         snapshot_file = self.get_filepath(index)
         snapshot_name = self.get_snapshot_name(index)
         self._file_hook(snapshot_file, snapshot_name)
-
-
-SnapshotIOClass = Callable[..., SnapshotIO]

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -26,14 +26,7 @@ class SnapshotIO:
             return os.path.join(test_dirname, SNAPSHOT_DIRNAME, snapshot_dir)
         return os.path.join(test_dirname, SNAPSHOT_DIRNAME)
 
-    def discover_snapshots(self, index: int = 0) -> SnapshotFiles:
-        """
-        Utility method for getting all the snapshots from an assertion.
-        """
-        filepath = self.get_filepath(index)
-        return {filepath: self.discover_snapshots_in_file(filepath)}
-
-    def discover_snapshots_in_file(self, filepath: str) -> Set[str]:
+    def discover_snapshots(self, filepath: str) -> Set[str]:
         """
         Utility method for getting all the snapshots from a file.
         Returns an empty set if the file cannot be read.
@@ -82,7 +75,7 @@ class SnapshotIO:
         return snapshot
 
     def post_read(self, index: int = 0):
-        self._file_hook(self.get_filepath(index))
+        self._snap_file_hook(index)
 
     def pre_write(self, data: Any, index: int = 0):
         self._ensure_snapshot_dir(index)
@@ -93,7 +86,7 @@ class SnapshotIO:
         self._write_snapshot_or_remove_file(snapshot_file, snapshot_name, data)
 
     def post_write(self, data: Any, index: int = 0):
-        self._file_hook(self.get_filepath(index))
+        self._snap_file_hook(index)
 
     def get_snapshot_name(self, index: int = 0) -> str:
         index_suffix = f".{index}" if index > 0 else ""
@@ -166,6 +159,14 @@ class SnapshotIO:
         """
         with open(filepath, "w") as f:
             yaml.safe_dump(data, f)
+
+    def _snap_file_hook(self, index: int):
+        """
+        Notify the assertion of an access to a snapshot in a file
+        """
+        snapshot_file = self.get_filepath(index)
+        snapshot_name = self.get_snapshot_name(index)
+        self._file_hook(snapshot_file, snapshot_name)
 
 
 SnapshotIOClass = Callable[..., SnapshotIO]

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Set
 
 import os
 import yaml
@@ -71,8 +71,13 @@ class SnapshotIO:
 
     def discover_snapshots(self, index: int = 0) -> SnapshotFiles:
         filepath = self.get_filepath(index)
-        snapshots = self._read_file(filepath)
-        return {filepath: set(snapshots.keys())}
+        return {filepath: self.discover_snapshots_in_file(filepath)}
+
+    def discover_snapshots_in_file(self, filepath: str) -> Set[str]:
+        try:
+            return set(self._read_file(filepath).keys())
+        except:
+            return set()
 
     def get_snapshot_name(self, index: int = 0) -> str:
         index_suffix = f".{index}" if index > 0 else ""

--- a/src/syrupy/plugins/image/__init__.py
+++ b/src/syrupy/plugins/image/__init__.py
@@ -4,11 +4,11 @@ from .serializer import ImageSnapshotSerializer
 
 class PNGImageSnapshotIO(AbstractImageSnapshotIO):
     @property
-    def extension(self):
+    def extension(self) -> str:
         return "png"
 
 
 class SVGImageSnapshotIO(AbstractImageSnapshotIO):
     @property
-    def extension(self):
+    def extension(self) -> str:
         return "svg"

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -15,10 +15,7 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
     def extension(self) -> str:
         pass
 
-    def discover_snapshots(self, index: int = 0) -> SnapshotFiles:
-        return {self.get_filepath(index): {self.get_snapshot_name(index)}}
-
-    def discover_snapshots_in_file(self, filepath: str) -> Set[str]:
+    def discover_snapshots(self, filepath: str) -> Set[str]:
         return {os.path.splitext(os.path.basename(filepath))[0]}
 
     def get_file_basename(self, index: int) -> str:

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -48,5 +48,5 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
 
     def _clean_filename(self, filename: str) -> str:
         filename = str(filename).strip().replace(" ", "_")
-        max_filename_length = 255 - (len(self.extension) if self.extension else 0)
+        max_filename_length = 255 - len(self.extension or "")
         return re.sub(r"(?u)[^-\w.]", "", filename)[:max_filename_length]

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -19,17 +19,15 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
         return {self.get_filepath(index): {self.get_snapshot_name(index)}}
 
     def discover_snapshots_in_file(self, filepath: str) -> Set[str]:
-        return set()
+        return {os.path.splitext(os.path.basename(filepath))[0]}
 
     def get_file_basename(self, index: int) -> str:
         ext = f".{self.extension}"
-        sanitized_name = self._clean_filename(self.get_snapshot_name(index=index))[
-            : 255 - len(ext)
-        ]
-        return f"{sanitized_name}{ext}"
+        sanitized_name = self._clean_filename(self.get_snapshot_name(index=index))
+        return f"{sanitized_name[:255 - len(ext)]}{ext}"
 
     def _get_snapshot_dirname(self):
-        return os.path.basename(str(self.test_location.filename)[: -len(".py")])
+        return os.path.splitext(os.path.basename(str(self.test_location.filename)))[0]
 
     def _read_snapshot_from_file(self, snapshot_file: str, _):
         return self._read_file(snapshot_file)

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Set
 from abc import ABC, abstractmethod
 import re
 
@@ -17,6 +17,9 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
 
     def discover_snapshots(self, index: int = 0) -> SnapshotFiles:
         return {self.get_filepath(index): {self.get_snapshot_name(index)}}
+
+    def discover_snapshots_in_file(self, filepath: str) -> Set[str]:
+        return set()
 
     def get_file_basename(self, index: int) -> str:
         ext = f".{self.extension}"

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -6,6 +6,7 @@ import os
 
 from syrupy.io import SnapshotIO
 from syrupy.exceptions import SnapshotDoesNotExist
+from syrupy.types import Albums
 
 
 class AbstractImageSnapshotIO(ABC, SnapshotIO):
@@ -14,27 +15,39 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
     def extension(self):
         return None
 
-    def write(self, data, index: int = 0):
-        with open(self.get_filepath(index), "wb") as f:
-            f.write(data)
-
-    def read(self, index: int = 0) -> Any:
-        try:
-            with open(self.get_filepath(index), "rb") as f:
-                return f.read()
-        except FileNotFoundError:
-            raise SnapshotDoesNotExist()
-
-    def get_snapshot_dirname(self) -> str:
-        return os.path.basename(str(self.test_location.filename)[: -len(".py")])
+    def discover_snapshots(self, index: int = 0) -> Albums:
+        return {self.get_filepath(index): {self.get_snapshot_name(index)}}
 
     def get_file_basename(self, index: int) -> str:
         ext = f".{self.extension}"
-        sanitized_name = self.get_valid_filename(self.get_snapshot_name(index=index))[
+        sanitized_name = self._clean_filename(self.get_snapshot_name(index=index))[
             : 255 - len(ext)
         ]
         return f"{sanitized_name}{ext}"
 
-    def get_valid_filename(self, filename: str) -> str:
+    def _get_snapshot_dirname(self):
+        return os.path.basename(str(self.test_location.filename)[: -len(".py")])
+
+    def _read_snapshot_from_file(self, snapshot_file: str, _):
+        return self._read_file(snapshot_file)
+
+    def _read_file(self, filepath: str) -> Any:
+        try:
+            with open(filepath, "rb") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+
+    def _write_snapshot_or_remove_file(self, snapshot_file: str, _: str, data: Any):
+        if data:
+            self._write_file(snapshot_file, data)
+        else:
+            os.remove(snapshot_file)
+
+    def _write_file(self, filepath: str, data: Any):
+        with open(filepath, "wb") as f:
+            f.write(data)
+
+    def _clean_filename(self, filename: str) -> str:
         filename = str(filename).strip().replace(" ", "_")
         return re.sub(r"(?u)[^-\w.]", "", filename)

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -1,4 +1,4 @@
-from typing import Any, Set
+from typing import Any, Set, Optional
 from abc import ABC, abstractmethod
 import re
 
@@ -12,8 +12,8 @@ from syrupy.types import SnapshotFiles
 class AbstractImageSnapshotIO(ABC, SnapshotIO):
     @property
     @abstractmethod
-    def extension(self):
-        return None
+    def extension(self) -> str:
+        pass
 
     def discover_snapshots(self, index: int = 0) -> SnapshotFiles:
         return {self.get_filepath(index): {self.get_snapshot_name(index)}}

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -19,9 +19,9 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
         return {os.path.splitext(os.path.basename(filepath))[0]}
 
     def get_file_basename(self, index: int) -> str:
-        ext = f".{self.extension}"
+        maybe_extension = f".{self.extension}" if self.extension else ""
         sanitized_name = self._clean_filename(self.get_snapshot_name(index=index))
-        return f"{sanitized_name[:255 - len(ext)]}{ext}"
+        return f"{sanitized_name}{maybe_extension}"
 
     def _get_snapshot_dirname(self):
         return os.path.splitext(os.path.basename(str(self.test_location.filename)))[0]
@@ -48,4 +48,5 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
 
     def _clean_filename(self, filename: str) -> str:
         filename = str(filename).strip().replace(" ", "_")
-        return re.sub(r"(?u)[^-\w.]", "", filename)
+        max_filename_length = 255 - (len(self.extension) if self.extension else 0)
+        return re.sub(r"(?u)[^-\w.]", "", filename)[:max_filename_length]

--- a/src/syrupy/plugins/image/io.py
+++ b/src/syrupy/plugins/image/io.py
@@ -6,7 +6,7 @@ import os
 
 from syrupy.io import SnapshotIO
 from syrupy.exceptions import SnapshotDoesNotExist
-from syrupy.types import Albums
+from syrupy.types import SnapshotFiles
 
 
 class AbstractImageSnapshotIO(ABC, SnapshotIO):
@@ -15,7 +15,7 @@ class AbstractImageSnapshotIO(ABC, SnapshotIO):
     def extension(self):
         return None
 
-    def discover_snapshots(self, index: int = 0) -> Albums:
+    def discover_snapshots(self, index: int = 0) -> SnapshotFiles:
         return {self.get_filepath(index): {self.get_snapshot_name(index)}}
 
     def get_file_basename(self, index: int) -> str:

--- a/src/syrupy/serializer.py
+++ b/src/syrupy/serializer.py
@@ -10,6 +10,3 @@ class SnapshotSerializer:
 
     def decode(self, data):
         return data
-
-
-SnapshotSerializerClass = Callable[..., SnapshotSerializer]

--- a/src/syrupy/serializer.py
+++ b/src/syrupy/serializer.py
@@ -1,3 +1,6 @@
+from typing import Callable
+
+
 class SnapshotSerializer:
     def __init__(self):
         pass
@@ -7,3 +10,6 @@ class SnapshotSerializer:
 
     def decode(self, data):
         return data
+
+
+SnapshotSerializerClass = Callable[..., SnapshotSerializer]

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -109,7 +109,8 @@ class SnapshotSession:
             }
         )
 
-    def register_assertion(self, assertion: SnapshotAssertion, executions: int):
+    def register_assertion(self, assertion: SnapshotAssertion):
+        executions = assertion.num_executions
         self.add_discovered_snapshots(assertion.io.discover_snapshots(executions))
 
         filepath = assertion.io.get_filepath(executions)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -156,7 +156,7 @@ class SnapshotSession:
         }
 
     def _count_snapshots(self, snapshot_files: SnapshotFiles) -> int:
-        return sum(map(len, snapshot_files.values()))
+        return sum(len(snaps) for snaps in snapshot_files.values())
 
     def _in_snapshot_dir(self, path: str) -> bool:
         parts = path.split(os.path.sep)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -130,15 +130,13 @@ class SnapshotSession:
         self._merge_snapshot_files_into(self.visited_snapshots, snapshots)
 
     def remove_unused_snapshots(self):
-        for snapshot_file, snapshots in self.unused_snapshots.items():
-            # All discovered snapshots in the file are unused
-            if self.discovered_snapshots[snapshot_file] == snapshots:
+        for snapshot_file, unused_snapshots in self.unused_snapshots.items():
+            if self.discovered_snapshots[snapshot_file] == unused_snapshots:
                 os.remove(snapshot_file)
                 continue
-            # The snapshot file should have at least one registered assertion
-            snapshot_file_assertion, *_ = self._assertions[snapshot_file].values()
-            for snapshot_name in snapshots:
-                snapshot_file_assertion.io.delete_snapshot(snapshot_file, snapshot_name)
+            snapshot_assertion, *_ = self._assertions[snapshot_file].values()
+            for snapshot_name in unused_snapshots:
+                snapshot_assertion.io.delete_snapshot(snapshot_file, snapshot_name)
 
     def _merge_snapshot_files_into(
         self, snapshot_files: SnapshotFiles, *snapshot_files_to_merge: SnapshotFiles,

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -101,7 +101,7 @@ class SnapshotSession:
             {filepath: set() for filepath in self._walk_dir(assertion.io.dirname)}
         )
 
-    def register_assertion(self, assertion: SnapshotAssertion, executions: int = 0):
+    def register_assertion(self, assertion: SnapshotAssertion, executions: int):
         self.add_discovered_snapshots(assertion.io.discover_snapshots(executions))
 
         filepath = assertion.io.get_filepath(executions)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -152,17 +152,13 @@ class SnapshotSession:
                     snapshot_files[filepath].update(snapshots)
 
     def _diff_snapshot_files(
-        self, snapshot_files_1: SnapshotFiles, snapshot_files_2: SnapshotFiles,
+        self, snapshot_files1: SnapshotFiles, snapshot_files2: SnapshotFiles,
     ) -> SnapshotFiles:
-        diffed = dict()
-        for filename, snapshots1 in snapshot_files_1.items():
-            snapshots2 = snapshot_files_2.get(filename)
-            if snapshots2 is None:
-                diffed[filename] = snapshots1
-            else:
-                result = snapshots1 - snapshots2
-                if result:
-                    diffed[filename] = result
+        diffed: SnapshotFiles = dict()
+        for filename, snapshots1 in snapshot_files1.items():
+            result = snapshots1 - snapshot_files2.get(filename, set())
+            if result:
+                diffed[filename] = result
         return diffed
 
     def _count_snapshots(self, snapshot_files: SnapshotFiles) -> int:

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -104,19 +104,15 @@ class SnapshotSession:
         self.report += [line]
 
     def register_request(self, assertion: SnapshotAssertion):
-        self.add_discovered_snapshots(
-            {
-                filepath: assertion.io.discover_snapshots_in_file(filepath)
-                for filepath in self._walk_dir(assertion.io.dirname)
-            }
-        )
+        discovered = {
+            filepath: assertion.io.discover_snapshots(filepath)
+            for filepath in self._walk_dir(assertion.io.dirname)
+        }
+        self.add_discovered_snapshots(discovered)
 
     def register_assertion(self, assertion: SnapshotAssertion):
-        executions = assertion.num_executions
-        self.add_discovered_snapshots(assertion.io.discover_snapshots(executions))
-
-        filepath = assertion.io.get_filepath(executions)
-        snapshot = assertion.io.get_snapshot_name(executions)
+        filepath = assertion.io.get_filepath(assertion.num_executions)
+        snapshot = assertion.io.get_snapshot_name(assertion.num_executions)
         self.add_visited_snapshots({filepath: {snapshot}})
 
         if filepath not in self._assertions:

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -156,7 +156,7 @@ class SnapshotSession:
         }
 
     def _count_snapshots(self, snapshot_files: SnapshotFiles) -> int:
-        return sum([len(snapshots) for _, snapshots in snapshot_files.items()])
+        return sum(len(snapshots) for _, snapshots in snapshot_files.items())
 
     def _in_snapshot_dir(self, path: str) -> bool:
         parts = path.split(os.path.sep)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -71,6 +71,8 @@ class SnapshotSession:
 
         for filepath, snapshots in self.unused_snapshots.items():
             count = self._count_snapshots({filepath: snapshots})
+            if not count:
+                continue
             path_to_file = os.path.relpath(filepath, self.base_dir)
             self.add_report_line(
                 ngettext(
@@ -154,18 +156,13 @@ class SnapshotSession:
     def _diff_snapshot_files(
         self, snapshot_files1: SnapshotFiles, snapshot_files2: SnapshotFiles,
     ) -> SnapshotFiles:
-        diffed: SnapshotFiles = dict()
-        for filename, snapshots1 in snapshot_files1.items():
-            result = snapshots1 - snapshot_files2.get(filename, set())
-            if result:
-                diffed[filename] = result
-        return diffed
+        return {
+            filename: snapshots1 - snapshot_files2.get(filename, set())
+            for filename, snapshots1 in snapshot_files1.items()
+        }
 
     def _count_snapshots(self, snapshot_files: SnapshotFiles) -> int:
-        count = 0
-        for _, snapshots in snapshot_files.items():
-            count += max(1, len(snapshots))
-        return count
+        return sum([len(snapshots) for _, snapshots in snapshot_files.items()])
 
     def _in_snapshot_dir(self, path: str) -> bool:
         parts = path.split(os.path.sep)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -156,7 +156,7 @@ class SnapshotSession:
         }
 
     def _count_snapshots(self, snapshot_files: SnapshotFiles) -> int:
-        return sum(len(snapshots) for _, snapshots in snapshot_files.items())
+        return sum(map(len, snapshot_files.values()))
 
     def _in_snapshot_dir(self, path: str) -> bool:
         parts = path.split(os.path.sep)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -1,44 +1,47 @@
 import os
+from collections import defaultdict
 from gettext import ngettext, gettext
-from typing import List, Set
+from typing import Dict, List, Set, Tuple
 
+from .assertion import SnapshotAssertion
 from .constants import SNAPSHOT_DIRNAME
 from .terminal import yellow, bold
+from .types import Albums
 
 
 class SnapshotSession:
     def __init__(self, *, update_snapshots: bool, base_dir: str):
         self.update_snapshots = update_snapshots
         self.base_dir = base_dir
-        self.discovered_snapshots: Set[str] = set()
-        self.visited_snapshots: Set[str] = set()
+        self.discovered_albums: Albums = dict()
+        self.visited_albums: Albums = dict()
         self.report: List[str] = []
+        self._assertions: Dict[str, Dict[str, SnapshotAssertion]] = dict()
+
+    @property
+    def unused_snapshots(self) -> Albums:
+        return self._subtract_albums(self.discovered_albums, self.visited_albums)
+
+    @property
+    def written_snapshots(self) -> Albums:
+        return self._subtract_albums(self.visited_albums, self.discovered_albums)
+
+    @property
+    def num_unused_snapshots(self):
+        return self._count_snapshots(self.unused_snapshots)
+
+    @property
+    def num_written_snapshots(self):
+        return self._count_snapshots(self.written_snapshots)
 
     def start(self):
         self.report = []
-        self.visited_snapshots = set()
-        self.discovered_snapshots = set(
-            filepath for filepath in self._walk_dir(self.base_dir)
-        )
-
-    @property
-    def unused_snapshots(self):
-        return self.discovered_snapshots - self.visited_snapshots
-
-    @property
-    def written_snapshots(self):
-        return self.visited_snapshots - self.discovered_snapshots
-
-    def add_visited_file(self, filepath: str):
-        if self._in_snapshot_dir(filepath):
-            self.visited_snapshots.add(filepath)
-
-    def add_report_line(self, line: str = ""):
-        self.report += [line]
+        self.visited_albums = dict()
+        self.discovered_albums = dict()
 
     def finish(self):
-        n_unused = len(self.unused_snapshots)
-        n_written = len(self.written_snapshots)
+        n_unused = self.num_unused_snapshots
+        n_written = self.num_written_snapshots
 
         self.add_report_line()
 
@@ -46,15 +49,13 @@ class SnapshotSession:
         if self.update_snapshots and n_written:
             summary_lines += [
                 ngettext(
-                    "{} snapshot file generated.",
-                    "{} snapshot files generated.",
-                    n_written,
+                    "{} snapshot generated.", "{} snapshots generated.", n_written,
                 ).format(bold(n_written))
             ]
         summary_lines += [
-            ngettext(
-                "{} snapshot file unused.", "{} snapshot files unused.", n_unused
-            ).format(bold(n_unused))
+            ngettext("{} snapshot unused.", "{} snapshots unused.", n_unused).format(
+                bold(n_unused)
+            )
         ]
         summary_line = " ".join(summary_lines)
         self.add_report_line(
@@ -63,8 +64,16 @@ class SnapshotSession:
             else summary_line
         )
 
-        for filepath in self.unused_snapshots:
-            self.add_report_line(f"  {os.path.relpath(filepath, self.base_dir)}")
+        for filepath, snapshots in self.unused_snapshots.items():
+            count = self._count_snapshots({filepath: snapshots})
+            path_to_file = os.path.relpath(filepath, self.base_dir)
+            self.add_report_line(
+                ngettext(
+                    f"{{}} at {path_to_file}",
+                    f"{{}} in {path_to_file} → {', '.join(snapshots)}",
+                    count,
+                ).format(bold(count))
+            )
 
         if n_unused:
             self.add_report_line()
@@ -72,28 +81,90 @@ class SnapshotSession:
                 self.remove_unused_snapshots()
                 self.add_report_line(
                     ngettext(
-                        "This file has been deleted.",
-                        "These files have been deleted.",
+                        "This snapshot has been deleted.",
+                        "These snapshots have been deleted.",
                         n_unused,
                     )
                 )
             else:
                 self.add_report_line(
                     gettext(
-                        "Re-run pytest with --update-snapshots to delete these files."
+                        "Re-run pytest with --update-snapshots to delete the snapshots."
                     )
                 )
 
+    def add_report_line(self, line: str = ""):
+        self.report += [line]
+
+    def register_request(self, assertion: SnapshotAssertion):
+        self.add_discovered_snapshots(
+            {filepath: set() for filepath in self._walk_dir(assertion.io.dirname)}
+        )
+
+    def register_assertion(self, assertion: SnapshotAssertion, executions: int = 0):
+        self.add_discovered_snapshots(assertion.io.discover_snapshots(executions))
+
+        filepath = assertion.io.get_filepath(executions)
+        snapshot = assertion.io.get_snapshot_name(executions)
+        self.add_visited_snapshots({filepath: {snapshot}})
+
+        if filepath not in self._assertions:
+            self._assertions[filepath] = dict()
+        self._assertions[filepath][snapshot] = assertion
+
+    def add_discovered_snapshots(self, albums: Albums):
+        self._merge_albums(self.discovered_albums, albums)
+
+    def add_visited_snapshots(self, albums: Albums):
+        self._merge_albums(self.visited_albums, albums)
+
     def remove_unused_snapshots(self):
-        for snapshot_file in self.unused_snapshots:
-            os.remove(snapshot_file)
+        for snapshot_file, snapshots in self.unused_snapshots.items():
+            # All discovered snapshots in the file are unused
+            if self.discovered_albums[snapshot_file] == snapshots:
+                os.remove(snapshot_file)
+                continue
+            # The snapshot file should have at least one registered assertion
+            snapshot_file_assertion, *_ = self._assertions[snapshot_file].values()
+            for snapshot_name in snapshots:
+                snapshot_file_assertion.io.delete_snapshot(snapshot_file, snapshot_name)
+
+    def _merge_albums(self, *albums_to_merge: Albums):
+        """
+        Add snapshots from other albums into the first one
+        """
+        merged_albums = albums_to_merge[0]
+        for albums in albums_to_merge[1:]:
+            for filepath, snapshots in albums.items():
+                if self._in_snapshot_dir(filepath):
+                    if filepath not in merged_albums:
+                        merged_albums[filepath] = set()
+                    merged_albums[filepath].update(snapshots)
+
+    def _subtract_albums(self, album1: Albums, album2: Albums) -> Albums:
+        diff_albums = dict()
+        for filename, snapshots1 in album1.items():
+            snapshots2 = album2.get(filename)
+            if snapshots2 is None:
+                diff_albums[filename] = snapshots1
+            else:
+                result = snapshots1 - snapshots2
+                if result:
+                    diff_albums[filename] = result
+        return diff_albums
+
+    def _count_snapshots(self, albums: Albums) -> int:
+        count = 0
+        for _, snapshots in albums.items():
+            count += max(1, len(snapshots))
+        return count
 
     def _in_snapshot_dir(self, path: str) -> bool:
         parts = path.split(os.path.sep)
         return SNAPSHOT_DIRNAME in parts
 
     def _walk_dir(self, root: str):
-        for (dirpath, dirnames, filenames) in os.walk(root):
+        for (dirpath, _, filenames) in os.walk(root):
             if not self._in_snapshot_dir(dirpath):
                 continue
             for filename in filenames:

--- a/src/syrupy/types.py
+++ b/src/syrupy/types.py
@@ -1,0 +1,5 @@
+from typing import Dict, Set
+
+# This is a collection of album files
+# Each album is a collection of snapshot assertions
+Albums = Dict[str, Set[str]]

--- a/src/syrupy/types.py
+++ b/src/syrupy/types.py
@@ -1,5 +1,3 @@
 from typing import Dict, Set
 
-# This is a collection of album files
-# Each album is a collection of snapshot assertions
-Albums = Dict[str, Set[str]]
+SnapshotFiles = Dict[str, Set[str]]

--- a/tasks.py
+++ b/tasks.py
@@ -29,9 +29,12 @@ def lint(ctx, fix=False):
 
 
 @task
-def test(ctx, update_snapshots=False):
+def test(ctx, update_snapshots=False, verbose=False):
     ctx.run(
-        f"python -m pytest . {'--update-snapshots' if update_snapshots else ''}",
+        "python -m pytest ."
+        f"{' -s' if verbose else ''}"
+        f"{' --update-snapshots' if update_snapshots else ''}",
+        env={"PYTHONPATH": "./src"},
         pty=True,
     )
 

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -1,12 +1,3 @@
-test_dict:
-  data:
-    a:
-      e: false
-    b: true
-    c: Some text.
-    d:
-    - '1'
-    - 2
 test_dict[actual0]:
   data:
     a:
@@ -17,15 +8,6 @@ test_dict[actual0]:
     - '1'
     - 2
 test_dict[actual1]:
-  data:
-    a:
-      e: false
-    b: true
-    c: Some ttext.
-    d:
-    - '1'
-    - 2
-test_dict_1:
   data:
     a:
       e: false

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -7,6 +7,24 @@ test_dict:
     d:
     - '1'
     - 2
+test_dict[actual0]:
+  data:
+    a:
+      e: false
+    b: true
+    c: Some text.
+    d:
+    - '1'
+    - 2
+test_dict[actual1]:
+  data:
+    a:
+      e: false
+    b: true
+    c: Some ttext.
+    d:
+    - '1'
+    - 2
 test_dict_1:
   data:
     a:

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,10 +1,9 @@
 def test_fixture(testdir):
-    testdir.makepyfile(
-        """
-        def test_sth(snapshot):
-            assert snapshot is not None
-    """
-    )
+    pyfile_content = """
+def test_sth(snapshot):
+    assert snapshot is not None
+"""
+    testdir.makepyfile(pyfile_content)
 
     result = testdir.runpytest("-v")
     result.stdout.fnmatch_lines(["*::test_sth PASSED*"])

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -20,11 +20,12 @@ def test_parametrized_with_special_char(snapshot, expected):
     assert expected == snapshot
 
 
-def test_dict(snapshot):
-    actual = {"b": True, "c": "Some text.", "d": ["1", 2], "a": {"e": False}}
-    assert actual == snapshot
-
-
-def test_dict_1(snapshot):
-    actual = {"b": True, "c": "Some ttext.", "d": ["1", 2], "a": {"e": False}}
+@pytest.mark.parametrize(
+    "actual",
+    [
+        {"b": True, "c": "Some text.", "d": ["1", 2], "a": {"e": False}},
+        {"b": True, "c": "Some ttext.", "d": ["1", 2], "a": {"e": False}},
+    ],
+)
+def test_dict(snapshot, actual):
     assert actual == snapshot


### PR DESCRIPTION
## DevQA
- `inv test` should show unused snapshots in single file
- Comment out the `assert actual == snapshot_png` line in the image plugin test
https://github.com/tophat/syrupy/blob/1ad07661f3842557d1553c74f6b7976a7f8d81ef/tests/test_image_plugin.py#L22
- `inv test` should show that the image file is also unused
- `inv test -u` should update the snapshot files and remove the image snapshot file
- `inv test` should show no snapshot file is unused
- Comment out all the assertions in the `test_snapshot.py` file
- `inv test -u` should delete the `test_snapshot.yaml` file

## Comments
- This does not fail if there are unmatched snapshots but I think that should be a separate feature #13 