### PR TITLE
fix: compare snapshots without deserializing

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -91,15 +91,15 @@ class SnapshotAssertion:
     def _assert(self, data) -> bool:
         self._session.register_assertion(self)
         try:
+            serialized_data = self.serializer.encode(data)
             if self._update_snapshots:
-                serialized_data = self.serializer.encode(data)
                 self.io.create_or_update_snapshot(
                     serialized_data, index=self.num_executions
                 )
                 return True
 
-            deserialized = self._recall_data(index=self.num_executions)
-            if deserialized is None or data != deserialized:
+            snapshot_data = self._recall_data(index=self.num_executions)
+            if snapshot_data is None or serialized_data != snapshot_data:
                 return False
             return True
         finally:

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -92,16 +92,16 @@ class SnapshotAssertion:
         self._session.register_assertion(self)
         try:
             serialized_data = self.serializer.encode(data)
-            if self._update_snapshots:
+            snapshot_data = self._recall_data(index=self.num_executions)
+            matches = snapshot_data is not None and serialized_data == snapshot_data
+            if matches:
+                return True
+            if not matches and self._update_snapshots:
                 self.io.create_or_update_snapshot(
                     serialized_data, index=self.num_executions
                 )
                 return True
-
-            snapshot_data = self._recall_data(index=self.num_executions)
-            if snapshot_data is None or serialized_data != snapshot_data:
-                return False
-            return True
+            return False
         finally:
             self._executions += 1
 

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -94,14 +94,12 @@ class SnapshotAssertion:
             serialized_data = self.serializer.encode(data)
             snapshot_data = self._recall_data(index=self.num_executions)
             matches = snapshot_data is not None and serialized_data == snapshot_data
-            if matches:
-                return True
             if not matches and self._update_snapshots:
                 self.io.create_or_update_snapshot(
                     serialized_data, index=self.num_executions
                 )
                 return True
-            return False
+            return matches
         finally:
             self._executions += 1
 

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -66,12 +66,13 @@ class SnapshotAssertion:
         assert self == data
 
     def get_assert_diff(self, data) -> List[str]:
-        deserialized = self._recall_data(index=self.num_executions - 1)
-        if deserialized is None:
+        serialized_data = self.serializer.encode(data)
+        snapshot_data = self._recall_data(index=self.num_executions - 1)
+        if snapshot_data is None:
             return ["Snapshot does not exist!"]
 
-        if data != deserialized:
-            return [f"- {data}", f"+ {deserialized}"]
+        if serialized_data != snapshot_data:
+            return [f"- {serialized_data}", f"+ {snapshot_data}"]
 
         return []
 
@@ -106,7 +107,6 @@ class SnapshotAssertion:
 
     def _recall_data(self, index: int) -> Optional[Any]:
         try:
-            saved_data = self.io.read_snapshot(index=index)
-            return self.serializer.decode(saved_data)
+            return self.io.read_snapshot(index=index)
         except SnapshotDoesNotExist:
             return None

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -158,7 +158,7 @@ class SnapshotIO:
         Writes the snapshot data into the snapshot file that be read later.
         """
         with open(filepath, "w") as f:
-            yaml.dump(data, f)
+            yaml.dump(data, f, allow_unicode=True)
 
     def _snap_file_hook(self, index: int):
         """

--- a/src/syrupy/io.py
+++ b/src/syrupy/io.py
@@ -128,7 +128,7 @@ class SnapshotIO:
         """
         try:
             with open(filepath, "r") as f:
-                return yaml.safe_load(f) or {}
+                return yaml.load(f, Loader=yaml.FullLoader) or {}
         except FileNotFoundError:
             pass
         return {}
@@ -158,7 +158,7 @@ class SnapshotIO:
         Writes the snapshot data into the snapshot file that be read later.
         """
         with open(filepath, "w") as f:
-            yaml.safe_dump(data, f)
+            yaml.dump(data, f)
 
     def _snap_file_hook(self, index: int):
         """

--- a/src/syrupy/serializer.py
+++ b/src/syrupy/serializer.py
@@ -1,5 +1,7 @@
 from typing import Callable
 
+import yaml
+
 
 class SnapshotSerializer:
     def __init__(self):

--- a/src/syrupy/serializer.py
+++ b/src/syrupy/serializer.py
@@ -1,7 +1,5 @@
 from typing import Callable
 
-import yaml
-
 
 class SnapshotSerializer:
     def __init__(self):

--- a/src/syrupy/serializer.py
+++ b/src/syrupy/serializer.py
@@ -7,6 +7,3 @@ class SnapshotSerializer:
 
     def encode(self, data):
         return data
-
-    def decode(self, data):
-        return data

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -36,9 +36,9 @@ test_set:
     this: null
 test_set.1:
   data: !!set
+    this: null
     is: null
     a: null
-    this: null
     ? !!python/object/apply:builtins.frozenset
     - - nested, set
     : null
@@ -59,3 +59,5 @@ test_tuples.1:
   - !!set
     named: null
     tuple: null
+test_unicode_string:
+  data: 🥞🐍🍯

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -1,4 +1,10 @@
-test_dict[actual0]:
+test_multiple_snapshots:
+  data: First.
+test_multiple_snapshots.1:
+  data: Second.
+test_multiple_snapshots.2:
+  data: Third.
+test_objects[actual0]:
   data:
     a:
       e: false
@@ -7,7 +13,7 @@ test_dict[actual0]:
     d:
     - '1'
     - 2
-test_dict[actual1]:
+test_objects[actual1]:
   data:
     a:
       e: false
@@ -16,12 +22,32 @@ test_dict[actual1]:
     d:
     - '1'
     - 2
-test_multiple_snapshots:
-  data: First.
-test_multiple_snapshots.1:
-  data: Second.
-test_multiple_snapshots.2:
-  data: Third.
+test_objects[actual2]:
+  data: !!set
+    a: null
+    is: null
+    set: null
+    this: null
+test_objects[actual3]:
+  data: !!set
+    this: null
+    is: null
+    a: null
+    ? !!python/object/apply:builtins.frozenset
+    - - nested, set
+    : null
+test_objects[actual4]:
+  data: !!python/tuple
+  - this
+  - is
+  - a
+  - tuple
+test_objects[actual5]:
+  data: !!python/object/new:tests.test_snapshots.ExampleTuple
+  - this
+  - is
+  - a
+  - namedtuple
 test_parametrized_with_special_char[Backslash \\u U]:
   data: Backslash \u U
 test_parametrized_with_special_char[Escaped \\n]:

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -1,10 +1,4 @@
-test_multiple_snapshots:
-  data: First.
-test_multiple_snapshots.1:
-  data: Second.
-test_multiple_snapshots.2:
-  data: Third.
-test_objects[actual0]:
+test_dict[actual0]:
   data:
     a:
       e: false
@@ -13,7 +7,7 @@ test_objects[actual0]:
     d:
     - '1'
     - 2
-test_objects[actual1]:
+test_dict[actual1]:
   data:
     a:
       e: false
@@ -22,37 +16,43 @@ test_objects[actual1]:
     d:
     - '1'
     - 2
-test_objects[actual2]:
+test_dict[actual2]:
   data: !!set
     a: null
     is: null
     set: null
     this: null
-test_objects[actual3]:
-  data: !!set
-    this: null
-    is: null
-    a: null
-    ? !!python/object/apply:builtins.frozenset
-    - - nested, set
-    : null
-test_objects[actual4]:
-  data: !!python/tuple
-  - this
-  - is
-  - a
-  - tuple
-test_objects[actual5]:
-  data: !!python/object/new:tests.test_snapshots.ExampleTuple
-  - this
-  - is
-  - a
-  - namedtuple
+test_multiple_snapshots:
+  data: First.
+test_multiple_snapshots.1:
+  data: Second.
+test_multiple_snapshots.2:
+  data: Third.
 test_parametrized_with_special_char[Backslash \\u U]:
   data: Backslash \u U
 test_parametrized_with_special_char[Escaped \\n]:
   data: Escaped \n
 test_raw_string:
   data: Raw string
+test_set:
+  data: !!set
+    is: null
+    a: null
+    ? !!python/object/apply:builtins.frozenset
+    - - nested, set
+    : null
+    this: null
 test_simple_string:
   data: Loreeeeeem ipsum.
+test_tuples:
+  data: !!python/tuple
+  - this
+  - is
+  - a
+  - tuple
+test_tuples.1:
+  data: !!python/object/new:tests.test_snapshots.ExampleTuple
+  - this
+  - is
+  - a
+  - namedtuple

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -16,12 +16,6 @@ test_dict[actual1]:
     d:
     - '1'
     - 2
-test_dict[actual2]:
-  data: !!set
-    a: null
-    is: null
-    set: null
-    this: null
 test_multiple_snapshots:
   data: First.
 test_multiple_snapshots.1:
@@ -36,23 +30,32 @@ test_raw_string:
   data: Raw string
 test_set:
   data: !!set
+    a: null
+    is: null
+    set: null
+    this: null
+test_set.1:
+  data: !!set
     is: null
     a: null
+    this: null
     ? !!python/object/apply:builtins.frozenset
     - - nested, set
     : null
-    this: null
 test_simple_string:
   data: Loreeeeeem ipsum.
 test_tuples:
   data: !!python/tuple
   - this
   - is
-  - a
-  - tuple
+  - !!python/tuple
+    - a
+    - tuple
 test_tuples.1:
   data: !!python/object/new:tests.test_snapshots.ExampleTuple
   - this
   - is
   - a
-  - namedtuple
+  - !!set
+    named: null
+    tuple: null

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -26,7 +26,6 @@ def test_parametrized_with_special_char(snapshot, expected):
     [
         {"b": True, "c": "Some text.", "d": ["1", 2], "a": {"e": False}},
         {"b": True, "c": "Some ttext.", "d": ["1", 2], "a": {"e": False}},
-        {"this", "is", "a", "set"},
     ],
 )
 def test_dict(snapshot, actual):
@@ -34,6 +33,7 @@ def test_dict(snapshot, actual):
 
 
 def test_set(snapshot):
+    assert snapshot == {"this", "is", "a", "set"}
     assert snapshot == {"this", "is", "a", frozenset({"nested, set"})}
 
 
@@ -41,5 +41,5 @@ ExampleTuple = namedtuple("ExampleTuple", ["a", "b", "c", "d"])
 
 
 def test_tuples(snapshot):
-    assert snapshot == ("this", "is", "a", "tuple")
-    assert snapshot == ExampleTuple(a="this", b="is", c="a", d="namedtuple")
+    assert snapshot == ("this", "is", ("a", "tuple"))
+    assert snapshot == ExampleTuple(a="this", b="is", c="a", d={"named", "tuple"})

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import pytest
 
 
@@ -20,12 +21,19 @@ def test_parametrized_with_special_char(snapshot, expected):
     assert expected == snapshot
 
 
+ExampleTuple = namedtuple("ExampleTuple", ["a", "b", "c", "d"])
+
+
 @pytest.mark.parametrize(
     "actual",
     [
         {"b": True, "c": "Some text.", "d": ["1", 2], "a": {"e": False}},
         {"b": True, "c": "Some ttext.", "d": ["1", 2], "a": {"e": False}},
+        {"this", "is", "a", "set"},
+        {"this", "is", "a", frozenset({"nested, set"})},
+        ("this", "is", "a", "tuple"),
+        ExampleTuple(a="this", b="is", c="a", d="namedtuple"),
     ],
 )
-def test_dict(snapshot, actual):
+def test_objects(snapshot, actual):
     assert actual == snapshot

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -21,19 +21,25 @@ def test_parametrized_with_special_char(snapshot, expected):
     assert expected == snapshot
 
 
-ExampleTuple = namedtuple("ExampleTuple", ["a", "b", "c", "d"])
-
-
 @pytest.mark.parametrize(
     "actual",
     [
         {"b": True, "c": "Some text.", "d": ["1", 2], "a": {"e": False}},
         {"b": True, "c": "Some ttext.", "d": ["1", 2], "a": {"e": False}},
         {"this", "is", "a", "set"},
-        {"this", "is", "a", frozenset({"nested, set"})},
-        ("this", "is", "a", "tuple"),
-        ExampleTuple(a="this", b="is", c="a", d="namedtuple"),
     ],
 )
-def test_objects(snapshot, actual):
+def test_dict(snapshot, actual):
     assert actual == snapshot
+
+
+def test_set(snapshot):
+    assert snapshot == {"this", "is", "a", frozenset({"nested, set"})}
+
+
+ExampleTuple = namedtuple("ExampleTuple", ["a", "b", "c", "d"])
+
+
+def test_tuples(snapshot):
+    assert snapshot == ("this", "is", "a", "tuple")
+    assert snapshot == ExampleTuple(a="this", b="is", c="a", d="namedtuple")

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -10,6 +10,10 @@ def test_raw_string(snapshot):
     assert r"Raw string" == snapshot
 
 
+def test_unicode_string(snapshot):
+    assert "🥞🐍🍯" == snapshot
+
+
 def test_multiple_snapshots(snapshot):
     assert "First." == snapshot
     snapshot.assert_match("Second.")


### PR DESCRIPTION
# Description

Fixes #21 

- [x] Do not deserialize to assert
- [x] Use `yaml.dump`
- [x] Do not rewrite matching snapshots