### PR TITLE
style: add strict typing

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+mypy_path=stubs

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Any, Optional, List
 
 from .assertion import SnapshotAssertion
 from .serializer import SnapshotSerializer
@@ -6,7 +7,7 @@ from .location import TestLocation
 from .session import SnapshotSession
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Any) -> None:
     """Exposes snapshot plugin configuration to pytest."""
     group = parser.getgroup("syrupy")
     group.addoption(
@@ -18,7 +19,7 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_assertrepr_compare(op, left, right):
+def pytest_assertrepr_compare(op: str, left: Any, right: Any) -> Optional[List[str]]:
     if isinstance(left, SnapshotAssertion):
         assert_msg = f"snapshot {op} {right}"
         return [assert_msg] + left.get_assert_diff(right)
@@ -28,7 +29,7 @@ def pytest_assertrepr_compare(op, left, right):
     return None
 
 
-def pytest_sessionstart(session):
+def pytest_sessionstart(session: Any) -> None:
     config = session.config
     session._syrupy = SnapshotSession(
         update_snapshots=config.option.update_snapshots, base_dir=config.rootdir
@@ -36,7 +37,7 @@ def pytest_sessionstart(session):
     session._syrupy.start()
 
 
-def pytest_sessionfinish(session):
+def pytest_sessionfinish(session: Any) -> None:
     reporter = session.config.pluginmanager.get_plugin("terminalreporter")
     session._syrupy.finish()
     for line in session._syrupy.report:
@@ -44,7 +45,7 @@ def pytest_sessionfinish(session):
 
 
 @pytest.fixture
-def snapshot(request):
+def snapshot(request: Any) -> "SnapshotAssertion":
     test_location = TestLocation(
         filename=request.fspath,
         modulename=request.module.__name__,

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -143,7 +143,9 @@ class SnapshotSession:
                 )
 
     def _merge_snapshot_files_into(
-        self, snapshot_files: "SnapshotFiles", *snapshot_files_to_merge: SnapshotFiles,
+        self,
+        snapshot_files: "SnapshotFiles",
+        *snapshot_files_to_merge: "SnapshotFiles",
     ) -> None:
         """
         Add snapshots from other files into the first one

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -2,55 +2,57 @@ import os
 from collections import defaultdict
 from functools import lru_cache
 from gettext import ngettext, gettext
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Generator, TYPE_CHECKING
 
-from .assertion import SnapshotAssertion
 from .constants import SNAPSHOT_DIRNAME
 from .terminal import yellow, bold
-from .types import SnapshotFiles
+
+if TYPE_CHECKING:
+    from .assertion import SnapshotAssertion
+    from .types import SnapshotFiles
 
 
 class SnapshotSession:
     def __init__(self, *, update_snapshots: bool, base_dir: str):
         self.update_snapshots = update_snapshots
         self.base_dir = base_dir
-        self.discovered_snapshots: SnapshotFiles = dict()
-        self.visited_snapshots: SnapshotFiles = dict()
+        self.discovered_snapshots: "SnapshotFiles" = dict()
+        self.visited_snapshots: "SnapshotFiles" = dict()
         self.report: List[str] = []
-        self._assertions: Dict[str, Dict[str, SnapshotAssertion]] = dict()
+        self._assertions: Dict[str, Dict[str, "SnapshotAssertion"]] = dict()
 
     @property
-    def unused_snapshots(self) -> SnapshotFiles:
+    def unused_snapshots(self) -> "SnapshotFiles":
         return self._diff_snapshot_files(
             self.discovered_snapshots, self.visited_snapshots
         )
 
     @property
-    def written_snapshots(self) -> SnapshotFiles:
+    def written_snapshots(self) -> "SnapshotFiles":
         return self._diff_snapshot_files(
             self.visited_snapshots, self.discovered_snapshots
         )
 
     @property
-    def num_unused_snapshots(self):
+    def num_unused_snapshots(self) -> int:
         return self._count_snapshots(self.unused_snapshots)
 
     @property
-    def num_written_snapshots(self):
+    def num_written_snapshots(self) -> int:
         return self._count_snapshots(self.written_snapshots)
 
-    def start(self):
+    def start(self) -> None:
         self.report = []
         self.visited_snapshots = dict()
         self.discovered_snapshots = dict()
 
-    def finish(self):
+    def finish(self) -> None:
         n_unused = self.num_unused_snapshots
         n_written = self.num_written_snapshots
 
         self.add_report_line()
 
-        summary_lines = []
+        summary_lines: List[str] = []
         if self.update_snapshots and n_written:
             summary_lines += [
                 ngettext(
@@ -100,17 +102,17 @@ class SnapshotSession:
                     )
                 )
 
-    def add_report_line(self, line: str = ""):
+    def add_report_line(self, line: str = "") -> None:
         self.report += [line]
 
-    def register_request(self, assertion: SnapshotAssertion):
+    def register_request(self, assertion: "SnapshotAssertion") -> None:
         discovered = {
             filepath: assertion.serializer.discover_snapshots(filepath)
             for filepath in self._walk_dir(assertion.serializer.dirname)
         }
         self.add_discovered_snapshots(discovered)
 
-    def register_assertion(self, assertion: SnapshotAssertion):
+    def register_assertion(self, assertion: "SnapshotAssertion") -> None:
         filepath = assertion.serializer.get_filepath(assertion.num_executions)
         snapshot = assertion.serializer.get_snapshot_name(assertion.num_executions)
         self.add_visited_snapshots({filepath: {snapshot}})
@@ -119,13 +121,13 @@ class SnapshotSession:
             self._assertions[filepath] = dict()
         self._assertions[filepath][snapshot] = assertion
 
-    def add_discovered_snapshots(self, snapshots: SnapshotFiles):
+    def add_discovered_snapshots(self, snapshots: "SnapshotFiles") -> None:
         self._merge_snapshot_files_into(self.discovered_snapshots, snapshots)
 
-    def add_visited_snapshots(self, snapshots: SnapshotFiles):
+    def add_visited_snapshots(self, snapshots: "SnapshotFiles") -> None:
         self._merge_snapshot_files_into(self.visited_snapshots, snapshots)
 
-    def remove_unused_snapshots(self):
+    def remove_unused_snapshots(self) -> None:
         for snapshot_file, unused_snapshots in self.unused_snapshots.items():
             all_discovered_unused = (
                 unused_snapshots == self.discovered_snapshots[snapshot_file]
@@ -141,8 +143,8 @@ class SnapshotSession:
                 )
 
     def _merge_snapshot_files_into(
-        self, snapshot_files: SnapshotFiles, *snapshot_files_to_merge: SnapshotFiles,
-    ):
+        self, snapshot_files: "SnapshotFiles", *snapshot_files_to_merge: SnapshotFiles,
+    ) -> None:
         """
         Add snapshots from other files into the first one
         """
@@ -154,14 +156,14 @@ class SnapshotSession:
                     snapshot_files[filepath].update(snapshots)
 
     def _diff_snapshot_files(
-        self, snapshot_files1: SnapshotFiles, snapshot_files2: SnapshotFiles,
-    ) -> SnapshotFiles:
+        self, snapshot_files1: "SnapshotFiles", snapshot_files2: "SnapshotFiles",
+    ) -> "SnapshotFiles":
         return {
             filename: snapshots1 - snapshot_files2.get(filename, set())
             for filename, snapshots1 in snapshot_files1.items()
         }
 
-    def _count_snapshots(self, snapshot_files: SnapshotFiles) -> int:
+    def _count_snapshots(self, snapshot_files: "SnapshotFiles") -> int:
         return sum(len(snaps) for snaps in snapshot_files.values())
 
     def _in_snapshot_dir(self, path: str) -> bool:
@@ -169,7 +171,7 @@ class SnapshotSession:
         return SNAPSHOT_DIRNAME in parts
 
     @lru_cache(maxsize=32)
-    def _walk_dir(self, root: str):
+    def _walk_dir(self, root: str) -> Generator[str, None, None]:
         for (dirpath, _, filenames) in os.walk(root):
             if not self._in_snapshot_dir(dirpath):
                 continue

--- a/src/syrupy/terminal.py
+++ b/src/syrupy/terminal.py
@@ -1,14 +1,17 @@
-def red(text):
+from typing import Union
+
+
+def red(text: Union[str, int]) -> str:
     return f"\033[31m{text}\033[0m"
 
 
-def yellow(text):
+def yellow(text: Union[str, int]) -> str:
     return f"\033[33m{text}\033[0m"
 
 
-def bold(text):
+def bold(text: Union[str, int]) -> str:
     return f"\033[1m{text}\033[0m"
 
 
-def error_style(text):
+def error_style(text: Union[str, int]) -> str:
     return bold(red(text))

--- a/src/syrupy/types.py
+++ b/src/syrupy/types.py
@@ -1,3 +1,4 @@
-from typing import Dict, Set
+from typing import Dict, Set, Any
 
 SnapshotFiles = Dict[str, Set[str]]
+SerializableData = Any

--- a/stubs/pytest.pyi
+++ b/stubs/pytest.pyi
@@ -1,0 +1,5 @@
+from typing import TypeVar, Callable, Any
+
+ReturnType = TypeVar("ReturnType")
+
+def fixture(func: Callable[..., ReturnType]) -> Callable[..., ReturnType]: ...

--- a/tasks.py
+++ b/tasks.py
@@ -25,7 +25,7 @@ def lint(ctx, fix=False):
         print("\nSkipping type check as there is no fixer")
     else:
         print("\nRunning type check")
-        ctx.run("python -m mypy --ignore-missing-imports src", pty=True)
+        ctx.run("python -m mypy --strict src", pty=True)
 
 
 @task


### PR DESCRIPTION
Uses forward references where possible. If we drop support for python 3.6, we can use implicit forward references via a future import. I think it's worth keeping 3.6 for now.