### PR TITLE
feat: change update opt to conform to snapshot test, close #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [TODO]
-
-- [docs] create a logo
-- [docs] fill out project maturity card
-- [feat] cli option to remove obsolete snapshots from within snapshot file
-- [feat] support rich diffs for large snapshots
-- [chore] setup tox for python 3.6 -> 3.8 support
-- [chore] publish package
-
 ## [Unreleased]
 
-- [feat] support --update-snapshots cli flag to write snapshots
+- [feat] support --snapshot-update cli flag to write snapshots
 - [feat] support custom plugins for writing snapshots, inc. image plugin

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ def test_foo(snapshot):
 when you run `pytest`, the above test should fail due to a missing snapshot. Re-run pytest with the update snapshots flag like so:
 
 ```shell
-pytest --update-snapshots
+pytest --snapshot-update
 ```
 
 A snapshot file should be generated under a `__snapshots__` directory in the same directory as `test_file.py`. The `__snapshots__` directory and all its children should be committed along with your test code.

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser: Any) -> None:
     """Exposes snapshot plugin configuration to pytest."""
     group = parser.getgroup("syrupy")
     group.addoption(
-        "--update-snapshots",
+        "--snapshot-update",
         action="store_true",
         default=False,
         dest="update_snapshots",

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -98,7 +98,7 @@ class SnapshotSession:
             else:
                 self.add_report_line(
                     gettext(
-                        "Re-run pytest with --update-snapshots to delete the snapshots."
+                        "Re-run pytest with --snapshot-update to delete the snapshots."
                     )
                 )
 

--- a/tasks.py
+++ b/tasks.py
@@ -29,11 +29,11 @@ def lint(ctx, fix=False):
 
 
 @task
-def test(ctx, update_snapshots=False, verbose=False):
+def test(ctx, snapshot_update=False, verbose=False):
     ctx.run(
         "python -m pytest ."
         f"{' -s' if verbose else ''}"
-        f"{' --update-snapshots' if update_snapshots else ''}",
+        f"{' --snapshot-update' if snapshot_update else ''}",
         env={"PYTHONPATH": "./src"},
         pty=True,
     )


### PR DESCRIPTION
I like "update-snapshots", however if this makes it easier to adopt, it's a minor point.