### PR TITLE
fix: yaml multiline string should be read successfully

### DIFF
--- a/src/syrupy/serializers/base.py
+++ b/src/syrupy/serializers/base.py
@@ -88,12 +88,13 @@ class AbstractSnapshotSerializer(ABC):
         self.write(data, index=index)
         self.post_write(data, index=index)
 
-    @final
+    @abstractmethod
     def delete_snapshot_from_file(self, snapshot_file: str, snapshot_name: str) -> None:
         """
-        Utility method for removing a snapshot from a snapshot file.
+        Remove a snapshot from a snapshot file.
+        If the snapshot file will be empty remove the entire file.
         """
-        self._write_snapshot_or_remove_file(snapshot_file, snapshot_name, None)
+        raise NotImplementedError
 
     def pre_read(self, index: int = 0) -> None:
         pass
@@ -119,7 +120,7 @@ class AbstractSnapshotSerializer(ABC):
     @final
     def write(self, data: "SerializableData", index: int = 0) -> None:
         """
-        Override `_write_snapshot_or_remove_file` in subclass to change behaviour
+        Override `_write_snapshot_to_file` in subclass to change behaviour
         """
         snapshot_file = self.get_filepath(index)
         snapshot_name = self.get_snapshot_name(index)
@@ -129,7 +130,7 @@ class AbstractSnapshotSerializer(ABC):
                 f" '{self.test_location.testname}'"
             )
             warnings.warn(warning_msg)
-        self._write_snapshot_or_remove_file(snapshot_file, snapshot_name, data)
+        self._write_snapshot_to_file(snapshot_file, snapshot_name, data)
 
     def post_write(self, data: "SerializableData", index: int = 0) -> None:
         pass
@@ -170,12 +171,10 @@ class AbstractSnapshotSerializer(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _write_snapshot_or_remove_file(
+    def _write_snapshot_to_file(
         self, snapshot_file: str, snapshot_name: str, data: "SerializableData"
     ) -> None:
         """
         Adds the snapshot data to the snapshots read from the file
-        or removes the snapshot entry if data is `None`.
-        If the snapshot file will be empty remove the entire file.
         """
         raise NotImplementedError

--- a/src/syrupy/serializers/raw_single.py
+++ b/src/syrupy/serializers/raw_single.py
@@ -44,13 +44,13 @@ class RawSingleSnapshotSerializer(AbstractSnapshotSerializer):
         except FileNotFoundError:
             return None
 
-    def _write_snapshot_or_remove_file(
+    def _write_snapshot_to_file(
         self, snapshot_file: str, snapshot_name: str, data: "SerializableData"
     ) -> None:
-        if data:
-            self.__write_file(snapshot_file, data)
-        else:
-            os.remove(snapshot_file)
+        self.__write_file(snapshot_file, data)
+
+    def delete_snapshot_from_file(self, snapshot_file: str, snapshot_name: str) -> None:
+        os.remove(snapshot_file)
 
     def __write_file(self, filepath: str, data: "SerializableData") -> None:
         with open(filepath, "wb") as f:

--- a/src/syrupy/serializers/yaml.py
+++ b/src/syrupy/serializers/yaml.py
@@ -40,7 +40,7 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
         snapshots = self._read_file(snapshot_file)
         if data is None and snapshot_name in snapshots:
             del snapshots[snapshot_name]
-        else:
+        elif data is not None:
             snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
             snapshots[snapshot_name][self._data_key] = data
 
@@ -89,12 +89,12 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
             with open(filepath, "r") as f:
                 test_name = None
                 for line in f:
-                    indent = len(line) - len(line.lstrip(" "))
-                    if not indent:
+                    if line[0] not in (" ", "\n") and line[-2] == ":":
                         test_name = line[:-2]  # newline & colon
                         snapshots[test_name] = ""
                     elif test_name is not None:
-                        snapshots[test_name] += line[2:]
+                        offset = min(len(line) - 1, 2)
+                        snapshots[test_name] += line[offset:]
         except FileNotFoundError:
             pass
 

--- a/src/syrupy/serializers/yaml.py
+++ b/src/syrupy/serializers/yaml.py
@@ -29,20 +29,18 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
         raw_snapshots = self._read_raw_file(snapshot_file)
         return raw_snapshots.get(snapshot_name, None)
 
-    def _write_snapshot_or_remove_file(
+    def _write_snapshot_to_file(
         self, snapshot_file: str, snapshot_name: str, data: "SerializableData"
     ) -> None:
-        """
-        Adds the snapshot data to the snapshots read from the file
-        or removes the snapshot entry if data is `None`.
-        If the snapshot file will be empty remove the entire file.
-        """
         snapshots = self._read_file(snapshot_file)
-        if data is None and snapshot_name in snapshots:
+        snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
+        snapshots[snapshot_name][self._data_key] = data
+        self.__write_file(snapshot_file, snapshots)
+
+    def delete_snapshot_from_file(self, snapshot_file: str, snapshot_name: str) -> None:
+        snapshots = self._read_file(snapshot_file)
+        if snapshot_name in snapshots:
             del snapshots[snapshot_name]
-        elif data is not None:
-            snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
-            snapshots[snapshot_name][self._data_key] = data
 
         if snapshots:
             self.__write_file(snapshot_file, snapshots)

--- a/src/syrupy/serializers/yaml.py
+++ b/src/syrupy/serializers/yaml.py
@@ -32,18 +32,18 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
     def _write_snapshot_to_file(
         self, snapshot_file: str, snapshot_name: str, data: "SerializableData"
     ) -> None:
-        snapshots = self._read_file(snapshot_file)
+        snapshots = self.__read_file(snapshot_file)
         snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
         snapshots[snapshot_name][self._data_key] = data
-        self._write_file(snapshot_file, snapshots)
+        self.__write_file(snapshot_file, snapshots)
 
     def delete_snapshot_from_file(self, snapshot_file: str, snapshot_name: str) -> None:
-        snapshots = self._read_file(snapshot_file)
+        snapshots = self.__read_file(snapshot_file)
         if snapshot_name in snapshots:
             del snapshots[snapshot_name]
 
         if snapshots:
-            self._write_file(snapshot_file, snapshots)
+            self.__write_file(snapshot_file, snapshots)
         else:
             os.remove(snapshot_file)
 
@@ -58,14 +58,14 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
     def _data_key(self) -> str:
         return "data"
 
-    def _write_file(self, filepath: str, data: "SerializableData") -> None:
+    def __write_file(self, filepath: str, data: "SerializableData") -> None:
         """
         Writes the snapshot data into the snapshot file that be read later.
         """
         with open(filepath, "w") as f:
             yaml.dump(data, f, allow_unicode=True)
 
-    def _read_file(self, filepath: str) -> Any:
+    def __read_file(self, filepath: str) -> Any:
         """
         Read the snapshot data from the snapshot file into a python instance.
         """

--- a/src/syrupy/serializers/yaml.py
+++ b/src/syrupy/serializers/yaml.py
@@ -35,7 +35,7 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
         snapshots = self._read_file(snapshot_file)
         snapshots[snapshot_name] = snapshots.get(snapshot_name, {})
         snapshots[snapshot_name][self._data_key] = data
-        self.__write_file(snapshot_file, snapshots)
+        self._write_file(snapshot_file, snapshots)
 
     def delete_snapshot_from_file(self, snapshot_file: str, snapshot_name: str) -> None:
         snapshots = self._read_file(snapshot_file)
@@ -43,7 +43,7 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
             del snapshots[snapshot_name]
 
         if snapshots:
-            self.__write_file(snapshot_file, snapshots)
+            self._write_file(snapshot_file, snapshots)
         else:
             os.remove(snapshot_file)
 
@@ -58,7 +58,7 @@ class YAMLSnapshotSerializer(AbstractSnapshotSerializer):
     def _data_key(self) -> str:
         return "data"
 
-    def __write_file(self, filepath: str, data: "SerializableData") -> None:
+    def _write_file(self, filepath: str, data: "SerializableData") -> None:
         """
         Writes the snapshot data into the snapshot file that be read later.
         """

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -142,11 +142,6 @@ class SnapshotSession:
                 self._serializers[snapshot_file].delete_snapshot_from_file(
                     snapshot_file, snapshot_name
                 )
-            if (
-                os.path.exists(snapshot_file)
-                and snapshot_file not in used_snapshot_files
-            ):
-                os.remove(snapshot_file)
 
     def _collate_snapshots(self) -> None:
         """

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -18,6 +18,10 @@ test_dict[actual1]:
     d:
     - '1'
     - 2
+test_multiline:
+  data: 'multi
+
+    line'
 test_multiple_snapshots:
   data: First.
 test_multiple_snapshots.1:
@@ -38,6 +42,14 @@ test_set:
     this: null
 test_simple_string:
   data: Loreeeeeem ipsum.
+test_singleline:
+  data: one-line
+test_singleline.1:
+  data: 'multi
+
+    line 2
+
+    line 3'
 test_tuples:
   data: !!python/tuple
   - this

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -18,6 +18,10 @@ test_dict[actual1]:
     d:
     - '1'
     - 2
+test_empty_snapshot:
+  data: null
+test_empty_snapshot.1:
+  data: ''
 test_multiple_snapshots:
   data: First.
 test_multiple_snapshots.1:

--- a/tests/__snapshots__/test_snapshots.yaml
+++ b/tests/__snapshots__/test_snapshots.yaml
@@ -18,46 +18,48 @@ test_dict[actual1]:
     d:
     - '1'
     - 2
-test_multiline:
-  data: 'multi
-
-    line'
 test_multiple_snapshots:
   data: First.
 test_multiple_snapshots.1:
   data: Second.
 test_multiple_snapshots.2:
   data: Third.
-test_parametrized_with_special_char[Backslash \\u U]:
-  data: Backslash \u U
-test_parametrized_with_special_char[Escaped \\n]:
-  data: Escaped \n
-test_raw_string:
-  data: Raw string
 test_set:
   data: !!set
     a: null
     is: null
     set: null
     this: null
-test_simple_string:
-  data: Loreeeeeem ipsum.
-test_singleline:
-  data: one-line
-test_singleline.1:
-  data: 'multi
+test_string[0]:
+  data: ''
+test_string[1]:
+  data: Raw string
+test_string[2]:
+  data: Escaped \n
+test_string[3]:
+  data: Backslash \u U
+test_string[4]:
+  data: 🥞🐍🍯
+test_string[5]:
+  data: 'singleline:'
+test_string[6]:
+  data: '- singleline'
+test_string[7]:
+  data: 'multi-line
 
     line 2
 
     line 3'
-test_tuples:
+test_string[8]:
+  data: "multi-line\nline 2\n  line 3"
+test_tuple:
   data: !!python/tuple
   - this
   - is
   - !!python/tuple
     - a
     - tuple
-test_tuples.1:
+test_tuple.1:
   data: !!python/object/new:tests.test_snapshots.ExampleTuple
   - this
   - is
@@ -65,5 +67,3 @@ test_tuples.1:
   - !!set
     named: null
     tuple: null
-test_unicode_string:
-  data: 🥞🐍🍯

--- a/tests/test_plugin_custom.py
+++ b/tests/test_plugin_custom.py
@@ -28,7 +28,10 @@ def testcases(testdir):
             def _read_snapshot_from_file(self, file, name):
                 pass
 
-            def _write_snapshot_or_remove_file(self, file, name, data):
+            def _write_snapshot_to_file(self, file, name, data):
+                pass
+
+            def delete_snapshot_from_file(self, file, name):
                 pass
 
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -12,6 +12,15 @@ def test_simple_string(snapshot):
     assert "Loreeeeeem ipsum." == snapshot
 
 
+def test_multiline(snapshot):
+    assert "multi\nline" == snapshot
+
+
+def test_singleline(snapshot):
+    assert "one-line" == snapshot
+    assert "multi\nline 2\nline 3" == snapshot
+
+
 def test_raw_string(snapshot):
     assert r"Raw string" == snapshot
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -8,6 +8,11 @@ def test_non_snapshots(snapshot):
         assert "Lorem ipsum." == "Muspi merol."
 
 
+def test_empty_snapshot(snapshot):
+    assert snapshot == None  # noqa: E711
+    assert snapshot == ""
+
+
 @pytest.mark.parametrize(
     "actual",
     [

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -8,36 +8,29 @@ def test_non_snapshots(snapshot):
         assert "Lorem ipsum." == "Muspi merol."
 
 
-def test_simple_string(snapshot):
-    assert "Loreeeeeem ipsum." == snapshot
-
-
-def test_multiline(snapshot):
-    assert "multi\nline" == snapshot
-
-
-def test_singleline(snapshot):
-    assert "one-line" == snapshot
-    assert "multi\nline 2\nline 3" == snapshot
-
-
-def test_raw_string(snapshot):
-    assert r"Raw string" == snapshot
-
-
-def test_unicode_string(snapshot):
-    assert "🥞🐍🍯" == snapshot
+@pytest.mark.parametrize(
+    "actual",
+    [
+        "",
+        r"Raw string",
+        r"Escaped \n",
+        r"Backslash \u U",
+        "🥞🐍🍯",
+        "singleline:",
+        "- singleline",
+        "multi-line\nline 2\nline 3",
+        "multi-line\nline 2\n  line 3",
+    ],
+    ids=lambda x: "",
+)
+def test_string(snapshot, actual):
+    assert snapshot == actual
 
 
 def test_multiple_snapshots(snapshot):
     assert "First." == snapshot
     snapshot.assert_match("Second.")
     snapshot("Third.")
-
-
-@pytest.mark.parametrize("expected", [r"Escaped \n", r"Backslash \u U"])
-def test_parametrized_with_special_char(snapshot, expected):
-    assert expected == snapshot
 
 
 @pytest.mark.parametrize(
@@ -58,7 +51,7 @@ def test_set(snapshot):
 ExampleTuple = namedtuple("ExampleTuple", ["a", "b", "c", "d"])
 
 
-def test_tuples(snapshot):
+def test_tuple(snapshot):
     assert snapshot == ("this", "is", ("a", "tuple"))
     assert snapshot == ExampleTuple(a="this", b="is", c="a", d={"named", "tuple"})
 


### PR DESCRIPTION
The bug this fixes:

Adding

```
def test_multiline(snapshot):
    assert "multi\nline" == snapshot
```

to its own test file and running `inv test -u` would create a corrupted file.