### PR TITLE
feat: fail unused snapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,6 @@ These are mostly guidelines, not rules. Use your best judgment, and feel free to
 
 - [Commit Messages](#commit-messages)
 - [Code Styleguide](#code-styleguide)
-- [Specs Styleguide](#specs-styleguide)
-- [Docs Styleguide](#docs-styleguide)
 
 [Additional Notes](#additional-notes)
 
@@ -40,13 +38,13 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 ## What should I know before I get started
 
-### Snapshot Testing
-
-- Javascript snapshot testing [jest](https:/a/jestjs.io/docs/en/snapshot-testing)
-
 ### Python 3
 
 - Python typing and hints: [typing](https://docs.python.org/3/library/typing.html)
+
+### Snapshot Testing
+
+- Javascript snapshot testing [jest](https:/a/jestjs.io/docs/en/snapshot-testing)
 
 ### Releases
 
@@ -91,12 +89,12 @@ Fill in the relevant sections, clearly linking the issue the change is attemping
 
 ## Styleguides
 
-### Git Commit Messages
+### Commit Messages
 
 Provide semantic commit messages following this [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).
 This informs the semantic versioning we use to control our [releases](#releases).
 
-### Specs Styleguide
+### Code Styleguide
 
 A linter is available to catch most of our styling concerns.
 This is provided in a pre-commit hook when setting up [local development](#local-development).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 ### Snapshot Testing
 
-- Javascript snapshot testing [jest](https:/a/jestjs.io/docs/en/snapshot-testing)
+- Javascript snapshot testing [jest](https://jestjs.io/docs/en/snapshot-testing)
 
 ### Releases
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ A snapshot file should be generated under a `__snapshots__` directory in the sam
 
 These are the cli options exposed to `pytest` by the plugin.
 
-| Option                   | Description                                                                                                               |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `--snapshot-update`      | When supplied updates existing snapshots of any run tests, as well as deleting unused and generating new snapshots.       |
+| Option                   | Description                                                                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `--snapshot-update`      | When supplied updates existing snapshots of any run tests, as well as deleting unused and generating new snapshots.          |
 | `--snapshot-warn-unused` | Syrupy default behaviour is to fail the test session when there any unused snapshots. This instructs the plugin not to fail. |
 
 ### Serializers

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These are the cli options exposed to `pytest` by the plugin.
 | Option                   | Description                                                                                                               |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
 | `--snapshot-update`      | When supplied updates existing snapshots of any run tests, as well as deleting unused and generating new snapshots.       |
-| `--snapshot-warn-unused` | Syrupy default behaviour is to fail the test session when there any unused snapshots. This instructs the plugin not fail. |
+| `--snapshot-warn-unused` | Syrupy default behaviour is to fail the test session when there any unused snapshots. This instructs the plugin not to fail. |
 
 ### Serializers
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ pytest --snapshot-update
 
 A snapshot file should be generated under a `__snapshots__` directory in the same directory as `test_file.py`. The `__snapshots__` directory and all its children should be committed along with your test code.
 
+### Options
+
+These are the cli options exposed to `pytest` by the plugin.
+
+| Option                   | Description                                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `--snapshot-update`      | When supplied updates existing snapshots of any run tests, as well as deleting unused and generating new snapshots.       |
+| `--snapshot-warn-unused` | Syrupy default behaviour is to fail the test session when there any unused snapshots. This instructs the plugin not fail. |
+
 ### Serializers
 
 Syrupy comes with a few built-in serializers for you to choose from. You should also feel free to extend the AbstractSnapshotSerializer if your project has a need not captured by one our built-ins.

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -26,10 +26,10 @@ def pytest_addoption(parser: Any) -> None:
         help="Update snapshots",
     )
     group.addoption(
-        "--unused-warn",
+        "--snapshot-unused-warn",
         action="store_true",
         default=False,
-        dest="warn_unused",
+        dest="warn_unused_snapshots",
         help="Do not fail on unused snapshots",
     )
 
@@ -55,7 +55,7 @@ def pytest_sessionstart(session: Any) -> None:
     """
     config = session.config
     session._syrupy = SnapshotSession(
-        warn_unused=config.option.warn_unused,
+        warn_unused_snapshots=config.option.warn_unused_snapshots,
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
     )

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -87,7 +87,7 @@ def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
     syrupy_exitstatus = session._syrupy.finish()
     for line in session._syrupy.report:
         reporter.write_line(line)
-    session.exitstatus = exitstatus | syrupy_exitstatus
+    session.exitstatus |= syrupy_exitstatus
 
 
 @pytest.fixture

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -87,7 +87,7 @@ def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
     syrupy_exitstatus = session._syrupy.finish()
     for line in session._syrupy.report:
         reporter.write_line(line)
-    session.exitstatus = exitstatus or syrupy_exitstatus
+    session.exitstatus = exitstatus | syrupy_exitstatus
 
 
 @pytest.fixture

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -26,7 +26,7 @@ def pytest_addoption(parser: Any) -> None:
         help="Update snapshots",
     )
     group.addoption(
-        "--snapshot-unused-warn",
+        "--snapshot-warn-unused",
         action="store_true",
         default=False,
         dest="warn_unused_snapshots",

--- a/src/syrupy/constants.py
+++ b/src/syrupy/constants.py
@@ -1,3 +1,5 @@
 SNAPSHOT_DIRNAME = "__snapshots__"
 SNAPSHOT_EMPTY_FILE = {"empty snapshot file"}
 SNAPSHOT_UNKNOWN_FILE = {"unknown snapshot file"}
+
+EXIT_STATUS_FAIL_UNUSED = 1

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -99,8 +99,8 @@ class SnapshotSession:
             ]
         if n_unused:
             if self.update_snapshots:
-                text_singular = "{} snapshot deleted."
-                text_plural = "{} snapshots deleted."
+                text_singular = "{} unused snapshot deleted."
+                text_plural = "{} unused snapshots deleted."
             else:
                 text_singular = "{} snapshot unused."
                 text_plural = "{} snapshots unused."

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -42,8 +42,10 @@ def empty_snapshot_groups() -> "SnapshotGroups":
 
 
 class SnapshotSession:
-    def __init__(self, *, warn_unused: bool, update_snapshots: bool, base_dir: str):
-        self.warn_unused = warn_unused
+    def __init__(
+        self, *, warn_unused_snapshots: bool, update_snapshots: bool, base_dir: str
+    ):
+        self.warn_unused_snapshots = warn_unused_snapshots
         self.update_snapshots = update_snapshots
         self.base_dir = base_dir
         self.report: List[str] = []
@@ -104,7 +106,7 @@ class SnapshotSession:
             else:
                 text_singular = "{} snapshot unused."
                 text_plural = "{} snapshots unused."
-            if self.update_snapshots or self.warn_unused:
+            if self.update_snapshots or self.warn_unused_snapshots:
                 text_count = warning_style(n_unused)
             else:
                 text_count = error_style(n_unused)
@@ -132,7 +134,7 @@ class SnapshotSession:
                         " to delete the unused snapshots."
                     )
                 )
-                if not self.warn_unused:
+                if not self.warn_unused_snapshots:
                     exitstatus = 1
         return exitstatus
 

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -12,7 +12,10 @@ from typing import (
     Set,
 )
 
-from .constants import SNAPSHOT_UNKNOWN_FILE
+from .constants import (
+    EXIT_STATUS_FAIL_UNUSED,
+    SNAPSHOT_UNKNOWN_FILE,
+)
 from .location import TestLocation
 from .terminal import (
     bold,
@@ -125,17 +128,19 @@ class SnapshotSession:
                     path_to_file = os.path.relpath(filepath, self.base_dir)
                     deleted_snapshots = ", ".join(map(bold, sorted(snapshots)))
                     self.add_report_line(
-                        f"Deleted {deleted_snapshots} ({path_to_file})"
+                        gettext(f"Deleted {deleted_snapshots} ({path_to_file})")
                     )
             else:
-                self.add_report_line(
-                    gettext(
-                        "Re-run pytest with --snapshot-update"
-                        " to delete the unused snapshots."
-                    )
+                message = gettext(
+                    "Re-run pytest with --snapshot-update"
+                    " to delete the unused snapshots."
                 )
-                if not self.warn_unused_snapshots:
-                    exitstatus = 1
+                if self.warn_unused_snapshots:
+                    message = warning_style(message)
+                else:
+                    message = error_style(message)
+                    exitstatus = EXIT_STATUS_FAIL_UNUSED | exitstatus
+                self.add_report_line(message)
         return exitstatus
 
     def add_report_line(self, line: str = "") -> None:

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -139,7 +139,7 @@ class SnapshotSession:
                     message = warning_style(message)
                 else:
                     message = error_style(message)
-                    exitstatus = EXIT_STATUS_FAIL_UNUSED | exitstatus
+                    exitstatus |= EXIT_STATUS_FAIL_UNUSED
                 self.add_report_line(message)
         return exitstatus
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -227,7 +227,7 @@ def test_unused_snapshots(stubs):
     assert "snapshots generated" not in result_stdout
     assert "4 snapshots passed" in result_stdout
     assert "1 snapshot unused" in result_stdout
-    assert result.ret == 0
+    assert result.ret == 1
 
 
 def test_removed_snapshots(stubs):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ def test_collection(testdir):
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot passed" in result_stdout
     assert "1 snapshot updated" in result_stdout
-    assert "1 snapshot deleted" in result_stdout
+    assert "1 unused snapshot deleted" in result_stdout
 
 
 def test_collection_parametrized(testdir):
@@ -83,7 +83,7 @@ def test_collection_parametrized(testdir):
     result_stdout = clean_output(result.stdout.str())
     assert "2 snapshots passed" in result_stdout
     assert "snapshot updated" not in result_stdout
-    assert "1 snapshot deleted" in result_stdout
+    assert "1 unused snapshot deleted" in result_stdout
 
 
 @pytest.fixture
@@ -248,7 +248,7 @@ def test_removed_snapshots(stubs):
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
     assert "snapshot unused" not in result_stdout
-    assert "1 snapshot deleted" in result_stdout
+    assert "1 unused snapshot deleted" in result_stdout
     assert result.ret == 0
     assert os.path.isfile(filepath)
 
@@ -260,7 +260,7 @@ def test_removed_snapshot_file(stubs):
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
     assert "snapshots unused" not in result_stdout
-    assert "5 snapshots deleted" in result_stdout
+    assert "5 unused snapshots deleted" in result_stdout
     assert result.ret == 0
     assert not os.path.isfile(filepath)
 
@@ -274,7 +274,7 @@ def test_removed_empty_snapshot_file_only(stubs):
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
     assert os.path.relpath(filepath) not in result_stdout
-    assert "1 snapshot deleted" in result_stdout
+    assert "1 unused snapshot deleted" in result_stdout
     assert "empty snapshot file" in result_stdout
     assert os.path.relpath(empty_filepath) in result_stdout
     assert result.ret == 0
@@ -291,7 +291,7 @@ def test_removed_hanging_snapshot_file(stubs):
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
     assert os.path.relpath(filepath) not in result_stdout
-    assert "1 snapshot deleted" in result_stdout
+    assert "1 unused snapshot deleted" in result_stdout
     assert "unknown snapshot file" in result_stdout
     assert os.path.relpath(hanging_filepath) in result_stdout
     assert result.ret == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -230,6 +230,17 @@ def test_unused_snapshots(stubs):
     assert result.ret == 1
 
 
+def test_unused_snapshots_warning(stubs):
+    _, testdir, tests, _ = stubs
+    testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
+    result = testdir.runpytest("-v", "--unused-warn")
+    result_stdout = clean_output(result.stdout.str())
+    assert "snapshots generated" not in result_stdout
+    assert "4 snapshots passed" in result_stdout
+    assert "1 snapshot unused" in result_stdout
+    assert result.ret == 0
+
+
 def test_removed_snapshots(stubs):
     _, testdir, tests, filepath = stubs
     assert os.path.isfile(filepath)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -233,7 +233,7 @@ def test_unused_snapshots(stubs):
 def test_unused_snapshots_warning(stubs):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
-    result = testdir.runpytest("-v", "--snapshot-unused-warn")
+    result = testdir.runpytest("-v", "--snapshot-warn-unused")
     result_stdout = clean_output(result.stdout.str())
     assert "snapshots generated" not in result_stdout
     assert "4 snapshots passed" in result_stdout

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -233,7 +233,7 @@ def test_unused_snapshots(stubs):
 def test_unused_snapshots_warning(stubs):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
-    result = testdir.runpytest("-v", "--unused-warn")
+    result = testdir.runpytest("-v", "--snapshot-unused-warn")
     result_stdout = clean_output(result.stdout.str())
     assert "snapshots generated" not in result_stdout
     assert "4 snapshots passed" in result_stdout

--- a/tests/test_single_serializer.py
+++ b/tests/test_single_serializer.py
@@ -108,5 +108,5 @@ def test_updated_snapshots(stubs, testcases_updated):
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot updated" in result_stdout
-    assert "1 snapshot deleted" in result_stdout
+    assert "1 unused snapshot deleted" in result_stdout
     assert result.ret == 0


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Makes syrupy fail test session on unused snapshots.
Adds a flag `--snapshot-warn-unused` which can be used to allow warnings.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #13 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
