### PR TITLE
fix: declare attrs dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import (
 
 python_requires = "~=3.6"
 setup_requires = ["setuptools_scm"]
-install_requires = ["colored", "typing_extensions>=3.6"]
+install_requires = ["attrs>=18.2.0", "colored", "typing_extensions>=3.6"]
 dev_requires = [
     "black",
     "codecov",

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -49,8 +49,10 @@ class SnapshotAssertion:
     _serializer_class: Type["AbstractSnapshotSerializer"] = attr.ib(kw_only=True)
     _test_location: "TestLocation" = attr.ib(kw_only=True)
     _update_snapshots: bool = attr.ib(kw_only=True)
-    _executions: int = attr.ib(init=False, default=0)
-    _execution_results: Dict[int, "AssertionResult"] = attr.ib(init=False, factory=dict)
+    _executions: int = attr.ib(init=False, default=0, kw_only=True)
+    _execution_results: Dict[int, "AssertionResult"] = attr.ib(
+        init=False, factory=dict, kw_only=True
+    )
 
     def __attrs_post_init__(self) -> None:
         self._session.register_request(self)

--- a/src/syrupy/data.py
+++ b/src/syrupy/data.py
@@ -34,7 +34,7 @@ class SnapshotUnknown(Snapshot):
     name: str = attr.ib(default=SNAPSHOT_UNKNOWN_FILE_KEY, init=False)
 
 
-@attr.s(eq=False)
+@attr.s
 class SnapshotFile(object):
     filepath: str = attr.ib()
     _snapshots: Dict[str, "Snapshot"] = attr.ib(factory=dict)


### PR DESCRIPTION
## Description

We were missing the attrs dependency while relying on attrs>=19.2.0.

This PR adds the dependency to the setup.py and makes some minor changes so we're compatible with attrs==18.2.0.
