### PR TITLE
chore: explicit version ranges for required deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ from setuptools import (
 
 python_requires = "~=3.6"
 setup_requires = ["setuptools_scm"]
-install_requires = ["attrs>=18.2.0", "colored", "typing_extensions>=3.6"]
+install_requires = [
+    "attrs>=18.2.0,<20.0.0",
+    "colored>=1.3.92,<2.0.0",
+    "typing_extensions>=3.6,<4.0.0",
+]
 dev_requires = [
     "black",
     "codecov",


### PR DESCRIPTION
## Description

This PR defines explicit version ranges for the required dependencies, making the assumption that the dependencies follow semantic versioning (or at the minimum, won't release breaking changes without a major version bump).

## Additional Comments

We do not test in CI with old dependencies -- this wouldn't be feasible. I tested the minimum versions by installing the min. versions locally and running `inv test`.
