### PR TITLE
fix: allow hashable types to be used as dictionary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 ## Master (Unreleased)
 
+- Fix issue with using hashables as dict keys or in sets (#103)
 - Add support for custom objects repr (#101)
 - Add support for nested test classes (#99)
 - Remove `_snapshot_subdirectory_name` from `SnapshotFossilizer` (#99)

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -30,10 +30,10 @@
     a=1
     b='2'
     c=<class 'list'> [
-      ...,
       1,
       2,
       3,
+      ...,
     ]
     d=<class 'dict'> {
       'a': 1,
@@ -45,10 +45,10 @@
       a=1
       b='2'
       c=<class 'list'> [
-        ...,
         1,
         2,
         3,
+        ...,
       ]
       d=<class 'dict'> {
         'a': 1,
@@ -62,10 +62,10 @@
 ---
 # name: test_cycle[cyclic0]
   <class 'list'> [
-    ...,
     1,
     2,
     3,
+    ...,
   ]
 ---
 # name: test_cycle[cyclic1]
@@ -131,9 +131,9 @@
 ---
 # name: test_list
   <class 'list'> [
-    'string',
     1,
     2,
+    'string',
     <class 'dict'> {
       'key': 'value',
     },
@@ -243,8 +243,8 @@
 ---
 # name: test_tuple
   <class 'tuple'> (
-    'is',
     'this',
+    'is',
     <class 'tuple'> (
       'a',
       'tuple',
@@ -253,9 +253,9 @@
 ---
 # name: test_tuple.1
   <class 'ExampleTuple'> (
-    'a',
-    'is',
     'this',
+    'is',
+    'a',
     <class 'set'> {
       'named',
       'tuple',

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -30,10 +30,10 @@
     a=1
     b='2'
     c=<class 'list'> [
+      ...,
       1,
       2,
       3,
-      ...,
     ]
     d=<class 'dict'> {
       'a': 1,
@@ -45,10 +45,10 @@
       a=1
       b='2'
       c=<class 'list'> [
+        ...,
         1,
         2,
         3,
-        ...,
       ]
       d=<class 'dict'> {
         'a': 1,
@@ -62,10 +62,10 @@
 ---
 # name: test_cycle[cyclic0]
   <class 'list'> [
+    ...,
     1,
     2,
     3,
-    ...,
   ]
 ---
 # name: test_cycle[cyclic1]
@@ -110,9 +110,9 @@
 ---
 # name: test_list
   <class 'list'> [
+    'string',
     1,
     2,
-    'string',
     <class 'dict'> {
       'key': 'value',
     },
@@ -149,12 +149,34 @@
 ---
 # name: test_set[actual1]
   <class 'set'> {
+    'contains',
+    'frozen',
     <class 'frozenset'> {
       '1',
       '2',
     },
+  }
+---
+# name: test_set[actual2]
+  <class 'set'> {
     'contains',
-    'frozen',
+    'tuple',
+    <class 'tuple'> (
+      1,
+      2,
+    ),
+  }
+---
+# name: test_set[actual3]
+  <class 'set'> {
+    'contains',
+    'namedtuple',
+    <class 'ExampleTuple'> (
+      1,
+      2,
+      3,
+      4,
+    ),
   }
 ---
 # name: test_string[0]
@@ -200,8 +222,8 @@
 ---
 # name: test_tuple
   <class 'tuple'> (
-    'this',
     'is',
+    'this',
     <class 'tuple'> (
       'a',
       'tuple',
@@ -210,9 +232,9 @@
 ---
 # name: test_tuple.1
   <class 'ExampleTuple'> (
-    'this',
-    'is',
     'a',
+    'is',
+    'this',
     <class 'set'> {
       'named',
       'tuple',

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -139,7 +139,7 @@
 # name: test_reflection
   SnapshotAssertion(name='snapshot', num_executions=0)
 ---
-# name: test_set
+# name: test_set[actual0]
   <class 'set'> {
     'a',
     'is',
@@ -147,7 +147,7 @@
     'this',
   }
 ---
-# name: test_set.1
+# name: test_set[actual1]
   <class 'set'> {
     <class 'frozenset'> {
       '1',

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -102,6 +102,27 @@
     ],
   }
 ---
+# name: test_dict[actual2]
+  <class 'dict'> {
+    'a': 'Some ttext.',
+    1: True,
+    <class 'ExampleTuple'> (
+      1,
+      2,
+      3,
+      4,
+    ): <class 'dict'> {
+      'e': False,
+    },
+    <class 'frozenset'> {
+      '1',
+      '2',
+    }: <class 'list'> [
+      '1',
+      2,
+    ],
+  }
+---
 # name: test_empty_snapshot
   None
 ---

--- a/tests/__snapshots__/test_integration_default.ambr
+++ b/tests/__snapshots__/test_integration_default.ambr
@@ -8,9 +8,10 @@
   E       AssertionError: assert snapshot == received
   E           ...
   E         -   'be',
-  E         -   'updated',
-  E         +   'not',
   E         +   'match',
+  E         +   'not',
+  E           ...
+  E         -   'updated',
   E           ...
   
   test_file.py:17: AssertionError
@@ -21,8 +22,9 @@
   >       assert ['this', 'will', 'fail'] == snapshot
   E       AssertionError: assert received == snapshot
   E           ...
-  E         +   'fail',
   E         -   'be',
+  E         +   'fail',
+  E           ...
   E         -   'updated',
   E           ...
   
@@ -34,9 +36,10 @@
   >       assert snapshot == ['this', 'will', 'be', 'too', 'much']
   E       AssertionError: assert snapshot == received
   E           ...
+  E         +   'much',
+  E           ...
   E         -   'updated',
   E         +   'too',
-  E         +   'much',
   E           ...
   
   test_file.py:27: AssertionError

--- a/tests/__snapshots__/test_integration_default.ambr
+++ b/tests/__snapshots__/test_integration_default.ambr
@@ -8,10 +8,9 @@
   E       AssertionError: assert snapshot == received
   E           ...
   E         -   'be',
-  E         +   'match',
-  E         +   'not',
-  E           ...
   E         -   'updated',
+  E         +   'not',
+  E         +   'match',
   E           ...
   
   test_file.py:17: AssertionError
@@ -22,9 +21,8 @@
   >       assert ['this', 'will', 'fail'] == snapshot
   E       AssertionError: assert received == snapshot
   E           ...
-  E         -   'be',
   E         +   'fail',
-  E           ...
+  E         -   'be',
   E         -   'updated',
   E           ...
   
@@ -36,10 +34,9 @@
   >       assert snapshot == ['this', 'will', 'be', 'too', 'much']
   E       AssertionError: assert snapshot == received
   E           ...
-  E         +   'much',
-  E           ...
   E         -   'updated',
   E         +   'too',
+  E         +   'much',
   E           ...
   
   test_file.py:27: AssertionError

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -49,17 +49,6 @@ def test_multiple_snapshots(snapshot):
     assert snapshot == "Third."
 
 
-@pytest.mark.parametrize(
-    "actual",
-    [
-        {"b": True, "c": "Some text.", "d": ["1", 2], "a": {"e": False}},
-        {"b": True, "c": "Some ttext.", "d": ["1", 2], "a": {"e": False}},
-    ],
-)
-def test_dict(snapshot, actual):
-    assert actual == snapshot
-
-
 ExampleTuple = namedtuple("ExampleTuple", ["a", "b", "c", "d"])
 
 
@@ -79,6 +68,23 @@ def test_tuple(snapshot):
 )
 def test_set(snapshot, actual):
     assert snapshot == actual
+
+
+@pytest.mark.parametrize(
+    "actual",
+    [
+        {"b": True, "c": "Some text.", "d": ["1", 2], "a": {"e": False}},
+        {"b": True, "c": "Some ttext.", "d": ["1", 2], "a": {"e": False}},
+        {
+            1: True,
+            "a": "Some ttext.",
+            frozenset({"1", "2"}): ["1", 2],
+            ExampleTuple(a=1, b=2, c=3, d=4): {"e": False},
+        },
+    ],
+)
+def test_dict(snapshot, actual):
+    assert actual == snapshot
 
 
 def test_numbers(snapshot):

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -60,17 +60,25 @@ def test_dict(snapshot, actual):
     assert actual == snapshot
 
 
-def test_set(snapshot):
-    assert snapshot == {"this", "is", "a", "set"}
-    assert snapshot == {"contains", "frozen", frozenset({"1", "2"})}
-
-
 ExampleTuple = namedtuple("ExampleTuple", ["a", "b", "c", "d"])
 
 
 def test_tuple(snapshot):
     assert snapshot == ("this", "is", ("a", "tuple"))
     assert snapshot == ExampleTuple(a="this", b="is", c="a", d={"named", "tuple"})
+
+
+@pytest.mark.parametrize(
+    "actual",
+    [
+        {"this", "is", "a", "set"},
+        {"contains", "frozen", frozenset({"1", "2"})},
+        {"contains", "tuple", (1, 2)}, # unsupported
+        {"contains", "namedtuple", ExampleTuple(a=1, b=2, c=3, d=4)}, # unsupported
+    ],
+)
+def test_set(snapshot, actual):
+    assert snapshot == actual
 
 
 def test_numbers(snapshot):

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -73,8 +73,8 @@ def test_tuple(snapshot):
     [
         {"this", "is", "a", "set"},
         {"contains", "frozen", frozenset({"1", "2"})},
-        {"contains", "tuple", (1, 2)}, # unsupported
-        {"contains", "namedtuple", ExampleTuple(a=1, b=2, c=3, d=4)}, # unsupported
+        {"contains", "tuple", (1, 2)},
+        {"contains", "namedtuple", ExampleTuple(a=1, b=2, c=3, d=4)},
     ],
 )
 def test_set(snapshot, actual):


### PR DESCRIPTION
## Description

Always sorts serialized values

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #102

## Checklist

- [x] This PR has sufficient test coverage.
- [x] I have updated the CHANGELOG.md.

## Additional Comments

N/A