### PR TITLE
fix: serialize carriage returns, #113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 ## Master (Unreleased)
 
-- Fix bug where newline control characters where being translated based on platform (#113)
+- Fix bug where newline control characters were being translated based on platform (#113)
 
 ## [v0.3.0](https://github.com/tophat/syrupy/compare/v0.2.0...v0.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 ## Master (Unreleased)
 
-Up to date with releases.
+- Fix bug where newline control characters where being translated based on platform (#113)
 
 ## [v0.3.0](https://github.com/tophat/syrupy/compare/v0.2.0...v0.3.0)
 

--- a/src/syrupy/extensions/amber.py
+++ b/src/syrupy/extensions/amber.py
@@ -36,14 +36,15 @@ class DataSerializer:
         Writes the snapshot data into the snapshot file that be read later.
         """
         filepath = snapshot_fossil.location
-        with open(filepath, "w") as f:
+        with open(filepath, "w", newline="") as f:
             for snapshot in sorted(snapshot_fossil, key=lambda s: s.name):
                 snapshot_data = str(snapshot.data)
                 if snapshot_data is not None:
                     f.write(f"{cls._marker_name} {snapshot.name}\n")
-                    for data_line in snapshot_data.split("\n"):
-                        f.write(f"{cls._indent}{data_line}\n")
-                    f.write(f"{cls._marker_divider}\n")
+                    print(snapshot_data.splitlines(keepends=True))
+                    for data_line in snapshot_data.splitlines(keepends=True):
+                        f.write(f"{cls._indent}{data_line}")
+                    f.write(f"\n{cls._marker_divider}\n")
 
     @classmethod
     def read_file(cls, filepath: str) -> "SnapshotFossil":
@@ -56,12 +57,12 @@ class DataSerializer:
         indent_len = len(cls._indent)
         snapshot_fossil = SnapshotFossil(location=filepath)
         try:
-            with open(filepath, "r") as f:
+            with open(filepath, "r", newline="") as f:
                 test_name = None
                 snapshot_data = ""
                 for line in f:
                     if line.startswith(cls._marker_name):
-                        test_name = line[name_marker_len:-1].strip(" \n")
+                        test_name = line[name_marker_len:-1].strip(" \r\n")
                         snapshot_data = ""
                         continue
                     elif test_name is not None:

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -148,6 +148,25 @@
 # name: test_multiple_snapshots.2
   'Third.'
 ---
+# name: test_newline_control_characters
+  '
+  line 1
+  line 2
+  '
+---
+# name: test_newline_control_characters.1
+  '
+  line 1
+  line 2
+  '
+---
+# name: test_newline_control_characters.2
+  '
+  line 1
+  line 2
+  
+  '
+---
 # name: test_numbers
   3.5
 ---

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -17,6 +17,12 @@ def test_empty_snapshot(snapshot):
     assert snapshot == ""
 
 
+def test_newline_control_characters(snapshot):
+    assert snapshot == "line 1\nline 2"
+    assert snapshot == "line 1\r\nline 2"
+    assert snapshot == "line 1\r\nline 2\r\n"
+
+
 @pytest.mark.parametrize("actual", [False, True])
 def test_bool(actual, snapshot):
     assert actual == snapshot


### PR DESCRIPTION
## Description

If a carriage return is present in a string, Syrupy will strip out the carriage return when serializing the data thus making the assertion persistently fail even after a snapshot-update.

This PR keeps the original newlines by explicitly setting the amber newlines arg of `open`.

## Related Issues

- Closes #113

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I have updated the CHANGELOG.md.

## Additional Comments

This does not fix the assertion reporter. With this PR, if you remove the `\r` from one of the assertions in the added test, you will get an extremely unhelpful diff of "...".