### PR TITLE
Ensure that untouched snapshots are not deleted in targeting mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 ## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)
 
-- Fix bug there untargeted snapshots would be deleted when using pytest in targeted mode (#123)
+- Fix bug where untargeted snapshots would be deleted when using pytest in targeted mode (#123)
 
 ## [v0.3.1](https://github.com/tophat/syrupy/compare/v0.3.0...v0.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 - Up to date with releases.
 
-## [v0.3.2](https://github.com/tophat/syrupy/compare/v.0.3.1...v0.3.2)
+## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)
 
 - Fix bug there untargeted snapshots would be deleted when using pytest in targeted mode (#123)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 ## Master (Unreleased)
 
-- Up to date with releases.
-
-## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)
-
 - Fix bug where untargeted snapshots would be deleted when using pytest in targeted mode (#123)
 
 ## [v0.3.1](https://github.com/tophat/syrupy/compare/v0.3.0...v0.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 - Up to date with releases.
 
+## [v0.3.2](https://github.com/tophat/syrupy/compare/v.0.3.1...v0.3.2)
+
+- Fix bug there untargeted snapshots would be deleted when using pytest in targeted mode (#123)
+
 ## [v0.3.1](https://github.com/tophat/syrupy/compare/v0.3.0...v0.3.1)
 
 - Fix bug where newline control characters were being translated based on platform (#113)

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -63,6 +63,9 @@ def pytest_sessionstart(session: Any) -> None:
         warn_unused_snapshots=config.option.warn_unused_snapshots,
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
+        targeted_items=[
+            arg for arg in config.invocation_params.args if not arg.startswith("-")
+        ],
     )
     session._syrupy.start()
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -1,3 +1,4 @@
+import os
 from typing import (
     Any,
     List,
@@ -64,7 +65,9 @@ def pytest_sessionstart(session: Any) -> None:
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
         targeted_items={
-            arg for arg in config.invocation_params.args if not arg.startswith("-")
+            arg
+            for arg in config.invocation_params.args
+            if not arg.startswith("-") and os.path.isfile(arg)
         },
     )
     session._syrupy.start()

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -1,4 +1,4 @@
-import os
+import glob
 from typing import (
     Any,
     List,
@@ -64,11 +64,10 @@ def pytest_sessionstart(session: Any) -> None:
         warn_unused_snapshots=config.option.warn_unused_snapshots,
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
-        targeted_items={
-            arg
+        is_providing_paths=any(
+            not arg.startswith("-") and glob.glob(arg)
             for arg in config.invocation_params.args
-            if not arg.startswith("-") and os.path.isfile(arg)
-        },
+        ),
     )
     session._syrupy.start()
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -63,9 +63,9 @@ def pytest_sessionstart(session: Any) -> None:
         warn_unused_snapshots=config.option.warn_unused_snapshots,
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
-        targeted_items=[
+        targeted_items={
             arg for arg in config.invocation_params.args if not arg.startswith("-")
-        ],
+        },
     )
     session._syrupy.start()
 

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -74,9 +74,7 @@ class SnapshotFossilizer(ABC):
         """Checks if supplied location is valid for this snapshot extension"""
         return location.endswith(self._file_extension)
 
-    def discover_snapshots(
-        self, snapshot_filter: Optional[Callable[["SnapshotFossil"], bool]] = None
-    ) -> "SnapshotFossils":
+    def discover_snapshots(self) -> "SnapshotFossils":
         """
         Returns all snapshot fossils in test site
         """
@@ -88,8 +86,6 @@ class SnapshotFossilizer(ABC):
                     snapshot_fossil = SnapshotEmptyFossil(location=filepath)
             else:
                 snapshot_fossil = SnapshotFossil(location=filepath)
-            if snapshot_filter and not snapshot_filter(snapshot_fossil):
-                continue
 
             discovered.add(snapshot_fossil)
 

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -8,6 +8,7 @@ from difflib import ndiff
 from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Generator,
     Optional,
@@ -74,7 +75,7 @@ class SnapshotFossilizer(ABC):
         """Checks if supplied location is valid for this snapshot extension"""
         return location.endswith(self._file_extension)
 
-    def discover_snapshots(self) -> "SnapshotFossils":
+    def discover_snapshots(self, snapshot_filter=None) -> "SnapshotFossils":
         """
         Returns all snapshot fossils in test site
         """
@@ -86,7 +87,10 @@ class SnapshotFossilizer(ABC):
                     snapshot_fossil = SnapshotEmptyFossil(location=filepath)
             else:
                 snapshot_fossil = SnapshotFossil(location=filepath)
+            if snapshot_filter and not snapshot_filter(snapshot_fossil):
+                continue
             discovered.add(snapshot_fossil)
+
         return discovered
 
     @final

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -8,7 +8,6 @@ from difflib import ndiff
 from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,
-    Any,
     Callable,
     Generator,
     Optional,
@@ -76,7 +75,7 @@ class SnapshotFossilizer(ABC):
         return location.endswith(self._file_extension)
 
     def discover_snapshots(
-        self, snapshot_filter: Optional[Callable[[Any], Any]] = None
+        self, snapshot_filter: Optional[Callable[["SnapshotFossil"], bool]] = None
     ) -> "SnapshotFossils":
         """
         Returns all snapshot fossils in test site

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -75,7 +75,9 @@ class SnapshotFossilizer(ABC):
         """Checks if supplied location is valid for this snapshot extension"""
         return location.endswith(self._file_extension)
 
-    def discover_snapshots(self, snapshot_filter=None) -> "SnapshotFossils":
+    def discover_snapshots(
+        self, snapshot_filter: Union[None, Callable[[Any], Any]] = None
+    ) -> "SnapshotFossils":
         """
         Returns all snapshot fossils in test site
         """
@@ -89,6 +91,7 @@ class SnapshotFossilizer(ABC):
                 snapshot_fossil = SnapshotFossil(location=filepath)
             if snapshot_filter and not snapshot_filter(snapshot_fossil):
                 continue
+
             discovered.add(snapshot_fossil)
 
         return discovered

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -76,7 +76,7 @@ class SnapshotFossilizer(ABC):
         return location.endswith(self._file_extension)
 
     def discover_snapshots(
-        self, snapshot_filter: Union[None, Callable[[Any], Any]] = None
+        self, snapshot_filter: Optional[Callable[[Any], Any]] = None
     ) -> "SnapshotFossils":
         """
         Returns all snapshot fossils in test site

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -83,10 +83,6 @@ class SnapshotReport(object):
             self.discovered.merge(SnapshotFossils(filtered_snaps))
 
     @property
-    def ran_test_files(self) -> List[str]:
-        return [ran_item.location[0] for ran_item in self.ran_items]
-
-    @property
     def num_created(self) -> int:
         return self._count_snapshots(self.created)
 

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -60,9 +60,13 @@ class SnapshotReport(object):
 
     def __attrs_post_init__(self) -> None:
         for assertion in self.assertions:
-            self.discovered.merge(
-                assertion.extension.discover_snapshots(self.filter_fossils)
-            )
+            discovered_snaps = assertion.extension.discover_snapshots()
+            filtered_snaps = {
+                snap.location: snap
+                for snap in discovered_snaps
+                if self.filter_fossils(snap)
+            }
+            self.discovered.merge(SnapshotFossils(filtered_snaps))
             for result in assertion.executions.values():
                 snapshot_fossil = SnapshotFossil(location=result.snapshot_location)
                 snapshot_fossil.add(

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -8,7 +8,6 @@ from typing import (
     Any,
     Generator,
     List,
-    Optional,
     Set,
 )
 
@@ -51,7 +50,7 @@ class SnapshotReport(object):
     used: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
 
     def filter_fossils(self, item: "SnapshotFossil") -> bool:
-        if not self.ran_test_files or not self.is_providing_paths:
+        if not self.ran_items or not self.is_providing_paths:
             return True
 
         target_snaps = {snap.location for snap in self.used}
@@ -83,7 +82,7 @@ class SnapshotReport(object):
                     self.failed.update(snapshot_fossil)
 
     @property
-    def ran_test_files(self) -> Optional[List[str]]:
+    def ran_test_files(self) -> List[str]:
         return [ran_item.location[0] for ran_item in self.ran_items]
 
     @property

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Generator,
     List,
+    Optional,
     Set,
 )
 
@@ -27,6 +28,7 @@ from .terminal import (
     success_style,
     warning_style,
 )
+from .utils import get_targeted_snapshots_from_targeted_files
 
 
 if TYPE_CHECKING:
@@ -41,7 +43,7 @@ class SnapshotReport(object):
     update_snapshots: bool = attr.ib()
     warn_unused_snapshots: bool = attr.ib()
     assertions: List["SnapshotAssertion"] = attr.ib()
-    targeted_items = attr.ib()
+    targeted_items: Optional[Set[Any]] = attr.ib()
     discovered: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     created: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     failed: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
@@ -49,11 +51,12 @@ class SnapshotReport(object):
     updated: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     used: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
 
-    def __filter(self, item):
-        from .utils import get_targeted_snapshots_from_targeted_files
+    def __filter(self, item: SnapshotFossil) -> bool:
+        if not self.targeted_items:
+            return True
 
-        c = get_targeted_snapshots_from_targeted_files(self.targeted_items)
-        return item.location in c
+        target_snaps = get_targeted_snapshots_from_targeted_files(self.targeted_items)
+        return item.location in target_snaps
 
     def __attrs_post_init__(self) -> None:
         for assertion in self.assertions:

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -50,7 +50,7 @@ class SnapshotReport(object):
     updated: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     used: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
 
-    def filter_fossils(self, item: SnapshotFossil) -> bool:
+    def filter_fossils(self, item: "SnapshotFossil") -> bool:
         if not self.ran_test_files or not self.is_providing_paths:
             return True
 

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -59,13 +59,6 @@ class SnapshotReport(object):
 
     def __attrs_post_init__(self) -> None:
         for assertion in self.assertions:
-            discovered_snaps = assertion.extension.discover_snapshots()
-            filtered_snaps = {
-                snap.location: snap
-                for snap in discovered_snaps
-                if self.filter_fossils(snap)
-            }
-            self.discovered.merge(SnapshotFossils(filtered_snaps))
             for result in assertion.executions.values():
                 snapshot_fossil = SnapshotFossil(location=result.snapshot_location)
                 snapshot_fossil.add(
@@ -80,6 +73,14 @@ class SnapshotReport(object):
                     self.matched.update(snapshot_fossil)
                 else:
                     self.failed.update(snapshot_fossil)
+
+            discovered_snaps = assertion.extension.discover_snapshots()
+            filtered_snaps = {
+                snap.location: snap
+                for snap in discovered_snaps
+                if self.filter_fossils(snap)
+            }
+            self.discovered.merge(SnapshotFossils(filtered_snaps))
 
     @property
     def ran_test_files(self) -> List[str]:

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -28,7 +28,6 @@ from .terminal import (
     success_style,
     warning_style,
 )
-from .utils import get_targeted_snapshots_from_targeted_files
 
 
 if TYPE_CHECKING:
@@ -55,9 +54,7 @@ class SnapshotReport(object):
         if not self.ran_test_files or not self.is_providing_paths:
             return True
 
-        target_snaps = set(
-            get_targeted_snapshots_from_targeted_files(self.ran_test_files)
-        )
+        target_snaps = {snap.location for snap in self.used}
 
         return item.location in target_snaps
 

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -41,6 +41,7 @@ class SnapshotReport(object):
     update_snapshots: bool = attr.ib()
     warn_unused_snapshots: bool = attr.ib()
     assertions: List["SnapshotAssertion"] = attr.ib()
+    targeted_items = attr.ib()
     discovered: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     created: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     failed: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
@@ -48,9 +49,15 @@ class SnapshotReport(object):
     updated: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     used: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
 
+    def __filter(self, item):
+        from .utils import get_targeted_snapshots_from_targeted_files
+
+        c = get_targeted_snapshots_from_targeted_files(self.targeted_items)
+        return item.location in c
+
     def __attrs_post_init__(self) -> None:
         for assertion in self.assertions:
-            self.discovered.merge(assertion.extension.discover_snapshots())
+            self.discovered.merge(assertion.extension.discover_snapshots(self.__filter))
             for result in assertion.executions.values():
                 snapshot_fossil = SnapshotFossil(location=result.snapshot_location)
                 snapshot_fossil.add(

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -11,7 +11,6 @@ from typing import (
 from .constants import EXIT_STATUS_FAIL_UNUSED
 from .data import SnapshotFossils
 from .report import SnapshotReport
-from .utils import get_targeted_snapshots_from_targeted_files
 
 
 if TYPE_CHECKING:
@@ -80,14 +79,8 @@ class SnapshotSession:
         unused_snapshot_fossils: "SnapshotFossils",
         used_snapshot_fossils: "SnapshotFossils",
     ) -> None:
-        targeted_snapshots = get_targeted_snapshots_from_targeted_files(
-            self.targeted_items
-        )
         for unused_snapshot_fossil in unused_snapshot_fossils:
             snapshot_location = unused_snapshot_fossil.location
-
-            if snapshot_location not in targeted_snapshots:
-                continue
 
             extension = self._extensions.get(snapshot_location)
             if extension:

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -25,13 +25,13 @@ class SnapshotSession:
         warn_unused_snapshots: bool,
         update_snapshots: bool,
         base_dir: str,
-        targeted_items: Optional[Set[str]],
+        is_providing_paths: bool,
     ):
         self.warn_unused_snapshots = warn_unused_snapshots
         self.update_snapshots = update_snapshots
         self.base_dir = base_dir
+        self.is_providing_paths: bool = is_providing_paths
         self.report: Optional["SnapshotReport"] = None
-        self.targeted_items: Optional[Set[Any]] = targeted_items
         self._all_items: Set[Any] = set()
         self._ran_items: Set[Any] = set()
         self._assertions: List["SnapshotAssertion"] = []
@@ -53,7 +53,7 @@ class SnapshotSession:
             assertions=self._assertions,
             update_snapshots=self.update_snapshots,
             warn_unused_snapshots=self.warn_unused_snapshots,
-            targeted_items=self.targeted_items,
+            is_providing_paths=self.is_providing_paths,
         )
         if self.report.num_unused:
             if self.update_snapshots:

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -32,7 +32,7 @@ class SnapshotSession:
         self.update_snapshots = update_snapshots
         self.base_dir = base_dir
         self.report: Optional["SnapshotReport"] = None
-        self.targeted_items = targeted_items
+        self.targeted_items: Optional[Set[Any]] = targeted_items
         self._all_items: Set[Any] = set()
         self._ran_items: Set[Any] = set()
         self._assertions: List["SnapshotAssertion"] = []
@@ -87,7 +87,6 @@ class SnapshotSession:
             snapshot_location = unused_snapshot_fossil.location
 
             if snapshot_location not in targeted_snapshots:
-                print("skip")
                 continue
 
             extension = self._extensions.get(snapshot_location)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -54,6 +54,7 @@ class SnapshotSession:
             assertions=self._assertions,
             update_snapshots=self.update_snapshots,
             warn_unused_snapshots=self.warn_unused_snapshots,
+            targeted_items=self.targeted_items,
         )
         if self.report.num_unused:
             if self.update_snapshots:
@@ -82,14 +83,11 @@ class SnapshotSession:
         targeted_snapshots = get_targeted_snapshots_from_targeted_files(
             self.targeted_items
         )
-        print(targeted_snapshots)
         for unused_snapshot_fossil in unused_snapshot_fossils:
             snapshot_location = unused_snapshot_fossil.location
 
-            print('_______________________' + snapshot_location)
-            print(snapshot_location in targeted_snapshots)
             if snapshot_location not in targeted_snapshots:
-                print('skip')
+                print("skip")
                 continue
 
             extension = self._extensions.get(snapshot_location)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -11,6 +11,7 @@ from typing import (
 from .constants import EXIT_STATUS_FAIL_UNUSED
 from .data import SnapshotFossils
 from .report import SnapshotReport
+from .utils import get_targeted_snapshots_from_targeted_files
 
 
 if TYPE_CHECKING:
@@ -20,12 +21,18 @@ if TYPE_CHECKING:
 
 class SnapshotSession:
     def __init__(
-        self, *, warn_unused_snapshots: bool, update_snapshots: bool, base_dir: str
+        self,
+        *,
+        warn_unused_snapshots: bool,
+        update_snapshots: bool,
+        base_dir: str,
+        targeted_items: Optional[Set[str]],
     ):
         self.warn_unused_snapshots = warn_unused_snapshots
         self.update_snapshots = update_snapshots
         self.base_dir = base_dir
         self.report: Optional["SnapshotReport"] = None
+        self.targeted_items = targeted_items
         self._all_items: Set[Any] = set()
         self._ran_items: Set[Any] = set()
         self._assertions: List["SnapshotAssertion"] = []
@@ -72,8 +79,19 @@ class SnapshotSession:
         unused_snapshot_fossils: "SnapshotFossils",
         used_snapshot_fossils: "SnapshotFossils",
     ) -> None:
+        targeted_snapshots = get_targeted_snapshots_from_targeted_files(
+            self.targeted_items
+        )
+        print(targeted_snapshots)
         for unused_snapshot_fossil in unused_snapshot_fossils:
             snapshot_location = unused_snapshot_fossil.location
+
+            print('_______________________' + snapshot_location)
+            print(snapshot_location in targeted_snapshots)
+            if snapshot_location not in targeted_snapshots:
+                print('skip')
+                continue
+
             extension = self._extensions.get(snapshot_location)
             if extension:
                 extension.delete_snapshots(

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -3,13 +3,12 @@ from typing import (
     Any,
     Generator,
     List,
-    Set,
 )
 
 from .constants import SNAPSHOT_DIRNAME
 
 
-def get_targeted_snapshots_from_targeted_files(targeted_files: Set[Any],) -> List[str]:
+def get_targeted_snapshots_from_targeted_files(targeted_files: List[Any],) -> List[str]:
     split_paths = [file_path.split("/") for file_path in targeted_files]
 
     return [

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -23,7 +23,7 @@ def get_targeted_snapshots_from_targeted_files(
             os.path.join(
                 *[
                     *split_path[:-1],
-                    "__snapshots__",
+                    SNAPSHOT_DIRNAME,
                     ".".join([os.path.splitext(split_path[-1])[0], "ambr"]),
                 ]
             )

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -11,15 +11,16 @@ def get_targeted_snapshots_from_targeted_files(targeted_files: Set[str]):
     split_paths = [file_path.split("/") for file_path in targeted_files]
     split_path = split_paths[0]
 
-
     return [
-        os.path.abspath(os.path.join(
-            *[
-                *split_path[:-1],
-                "__snapshots__",
-                ".".join([os.path.splitext(split_path[-1])[0], "ambr"]),
-            ]
-        ))
+        os.path.abspath(
+            os.path.join(
+                *[
+                    *split_path[:-1],
+                    "__snapshots__",
+                    ".".join([os.path.splitext(split_path[-1])[0], "ambr"]),
+                ]
+            )
+        )
         for split_path in split_paths
     ]
 

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -3,19 +3,13 @@ from typing import (
     Any,
     Generator,
     List,
-    Optional,
     Set,
 )
 
 from .constants import SNAPSHOT_DIRNAME
 
 
-def get_targeted_snapshots_from_targeted_files(
-    targeted_files: Optional[Set[Any]],
-) -> List[str]:
-    if not targeted_files:
-        return []
-
+def get_targeted_snapshots_from_targeted_files(targeted_files: Set[Any],) -> List[str]:
     split_paths = [file_path.split("/") for file_path in targeted_files]
 
     return [

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -1,15 +1,22 @@
 import os
 from typing import (
+    Any,
     Generator,
+    List,
+    Optional,
     Set,
 )
 
 from .constants import SNAPSHOT_DIRNAME
 
 
-def get_targeted_snapshots_from_targeted_files(targeted_files: Set[str]):
+def get_targeted_snapshots_from_targeted_files(
+    targeted_files: Optional[Set[Any]],
+) -> List[str]:
+    if not targeted_files:
+        return []
+
     split_paths = [file_path.split("/") for file_path in targeted_files]
-    split_path = split_paths[0]
 
     return [
         os.path.abspath(

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -1,7 +1,27 @@
 import os
-from typing import Generator
+from typing import (
+    Generator,
+    Set,
+)
 
 from .constants import SNAPSHOT_DIRNAME
+
+
+def get_targeted_snapshots_from_targeted_files(targeted_files: Set[str]):
+    split_paths = [file_path.split("/") for file_path in targeted_files]
+    split_path = split_paths[0]
+
+
+    return [
+        os.path.abspath(os.path.join(
+            *[
+                *split_path[:-1],
+                "__snapshots__",
+                ".".join([os.path.splitext(split_path[-1])[0], "ambr"]),
+            ]
+        ))
+        for split_path in split_paths
+    ]
 
 
 def in_snapshot_dir(path: str) -> bool:

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -1,28 +1,7 @@
 import os
-from typing import (
-    Any,
-    Generator,
-    List,
-)
+from typing import Generator
 
 from .constants import SNAPSHOT_DIRNAME
-
-
-def get_targeted_snapshots_from_targeted_files(targeted_files: List[Any],) -> List[str]:
-    split_paths = [file_path.split("/") for file_path in targeted_files]
-
-    return [
-        os.path.abspath(
-            os.path.join(
-                *[
-                    *split_path[:-1],
-                    SNAPSHOT_DIRNAME,
-                    ".".join([os.path.splitext(split_path[-1])[0], "ambr"]),
-                ]
-            )
-        )
-        for split_path in split_paths
-    ]
 
 
 def in_snapshot_dir(path: str) -> bool:

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -292,7 +292,7 @@ def test_unused_snapshots_ignored_if_not_targeted_when_targeting_using_dash_k(st
     assert os.path.isfile("__snapshots__/other_snapfile.ambr")
 
 
-def test_unused_snapshots_ignored_if_not_targeted_wdhen_targeting_specific_testfiles(
+def test_unused_snapshots_ignored_if_not_targeted_when_targeting_specific_testfiles(
     stubs,
 ):
     _, testdir, tests, _ = stubs

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -275,13 +275,11 @@ def test_mytest(stubs):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
     testdir.makefile(
-        ".ambr",
-        **{
-            "__snapshots__/other_snapfile": "---\n# name: other_snapfile.1\n\n\tsnapfile: 1\n---"
-        },
+        ".ambr", **{"__snapshots__/other_snapfile": ""},
     )
     result = testdir.runpytest("-v", "--snapshot-update", "test_file.py")
     result_stdout = clean_output(result.stdout.str())
+    assert "1 unused snapshot deleted" in result_stdout
     assert result.ret == 0
     assert os.path.isfile("__snapshots__/other_snapfile.ambr")
 

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -271,7 +271,7 @@ def test_unused_snapshots_warning(stubs):
     assert result.ret == 0
 
 
-def test_unused_snapshots_ignored_if_not_targeted_when_targeting_using_dash_k(stubs,):
+def test_unused_snapshots_ignored_if_not_targeted_when_targeting_using_dash_k(stubs):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
     testdir.makefile(

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -271,7 +271,28 @@ def test_unused_snapshots_warning(stubs):
     assert result.ret == 0
 
 
-def test_unused_snapshots_ignored_if_not_targeted_when_targeting_specific_testfiles(
+def test_unused_snapshots_ignored_if_not_targeted_when_targeting_using_dash_k(stubs,):
+    _, testdir, tests, _ = stubs
+    testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
+    testdir.makefile(
+        ".ambr", **{"__snapshots__/other_snapfile": ""},
+    )
+    test_content = (
+        "def test_life_always_finds_a_way(snapshot):\n\tassert snapshot == snapshot"
+    )
+    testdir.makefile(
+        ".py", **{"test_life_always_finds_a_way": test_content},
+    )
+    result = testdir.runpytest(
+        "-k", "life_always_finds_a_way", "-v", "--snapshot-update"
+    )
+    result_stdout = clean_output(result.stdout.str())
+    assert "1 snapshot generated" in result_stdout
+    assert result.ret == 0
+    assert os.path.isfile("__snapshots__/other_snapfile.ambr")
+
+
+def test_unused_snapshots_ignored_if_not_targeted_wdhen_targeting_specific_testfiles(
     stubs,
 ):
     _, testdir, tests, _ = stubs

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -271,7 +271,9 @@ def test_unused_snapshots_warning(stubs):
     assert result.ret == 0
 
 
-def test_mytest(stubs):
+def test_unused_snapshots_ignored_if_not_targeted_when_targeting_specific_testfiles(
+    stubs,
+):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
     testdir.makefile(

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -271,6 +271,18 @@ def test_unused_snapshots_warning(stubs):
     assert result.ret == 0
 
 
+def test_mytest(stubs):
+    _, testdir, tests, _ = stubs
+    testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
+    testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": "---\n# name: other_snapfile.1\n\n\tsnapfile: 1\n---"})
+    result = testdir.runpytest("-v", "--snapshot-update", "test_file.py")
+    result_stdout = clean_output(result.stdout.str())
+    assert "snapshots generated" not in result_stdout
+    assert "6 snapshots passed" in result_stdout
+    assert "1 snapshot unused" in result_stdout
+    assert result.ret == 0
+
+
 def test_removed_snapshots(stubs):
     _, testdir, tests, filepath = stubs
     assert os.path.isfile(filepath)

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -274,13 +274,16 @@ def test_unused_snapshots_warning(stubs):
 def test_mytest(stubs):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
-    testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": "---\n# name: other_snapfile.1\n\n\tsnapfile: 1\n---"})
+    testdir.makefile(
+        ".ambr",
+        **{
+            "__snapshots__/other_snapfile": "---\n# name: other_snapfile.1\n\n\tsnapfile: 1\n---"
+        },
+    )
     result = testdir.runpytest("-v", "--snapshot-update", "test_file.py")
     result_stdout = clean_output(result.stdout.str())
-    assert "snapshots generated" not in result_stdout
-    assert "6 snapshots passed" in result_stdout
-    assert "1 snapshot unused" in result_stdout
     assert result.ret == 0
+    assert os.path.isfile("__snapshots__/other_snapfile.ambr")
 
 
 def test_removed_snapshots(stubs):


### PR DESCRIPTION
## Description

This PR adds some handling around filenames that can be passed to `pytest` to target testfiles. Previously, passing in file paths would run the tests on these paths, and consider snapshots that weren't touched as unused -- even though they were actually used by other tests not targeted by `pytest` in that instance.

By passing down a list of targeted files and using a filtering function, this takes out snapshots that aren't related to the targeted files, if `pytest` is passed some paths. This way, `syrupy` no longer purges snapshots by mistake.

## Related Issues

This addresses #119.

## Checklist

- [x] This PR has sufficient test coverage.
- [x] I have updated the CHANGELOG.md.