### PR TITLE
Fix cleanup unused snapshots when targeting files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 ## Master (Unreleased)
 
 - Fix bug where untargeted snapshots would be deleted when using pytest in targeted mode (#123)
+- Fix bug where snapshot files were not cleaned up when running specific test files (#127)
+- Fix bug where targeting specific test nodes in a test file was not supported (#127)
 
 ## [v0.3.1](https://github.com/tophat/syrupy/compare/v0.3.0...v0.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 - Fix bug where untargeted snapshots would be deleted when using pytest in targeted mode (#123)
 - Fix bug where snapshot files were not cleaned up when running specific test files (#127)
 - Fix bug where targeting specific test nodes in a test file was not supported (#127)
+- Fix bug where targeting specific test modules using pyargs was not supported (#127)
 
 ## [v0.3.1](https://github.com/tophat/syrupy/compare/v0.3.0...v0.3.1)
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -65,7 +65,7 @@ def pytest_sessionstart(session: Any) -> None:
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
         is_providing_paths=any(
-            not arg.startswith("-") and glob.glob(arg)
+            not arg.startswith("-") and glob.glob(arg.split("::")[0])
             for arg in config.invocation_params.args
         ),
     )

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -54,6 +54,14 @@ def pytest_assertrepr_compare(op: str, left: Any, right: Any) -> Optional[List[s
     return None
 
 
+def __is_testpath(arg: str) -> bool:
+    return not arg.startswith("-") and bool(glob.glob(arg.split("::")[0]))
+
+
+def __is_testmodule(arg: str) -> bool:
+    return arg == "--pyargs"
+
+
 def pytest_sessionstart(session: Any) -> None:
     """
     Initialize snapshot session before tests are collected and ran.
@@ -65,7 +73,7 @@ def pytest_sessionstart(session: Any) -> None:
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
         is_providing_paths=any(
-            not arg.startswith("-") and glob.glob(arg.split("::")[0])
+            __is_testpath(arg) or __is_testmodule(arg)
             for arg in config.invocation_params.args
         ),
     )

--- a/src/syrupy/data.py
+++ b/src/syrupy/data.py
@@ -50,6 +50,8 @@ class SnapshotFossil(object):
 
     def add(self, snapshot: "Snapshot") -> None:
         self._snapshots[snapshot.name] = snapshot
+        if snapshot.name != SNAPSHOT_EMPTY_FOSSIL_KEY:
+            self.remove(SNAPSHOT_EMPTY_FOSSIL_KEY)
 
     def merge(self, snapshot_fossil: "SnapshotFossil") -> None:
         for snapshot in snapshot_fossil:
@@ -82,7 +84,7 @@ class SnapshotEmptyFossil(SnapshotFossil):
 
 @attr.s(frozen=True)
 class SnapshotUnknownFossil(SnapshotFossil):
-    """This is a saved fossil that is unclaimed by any extension currenly in use"""
+    """This is a saved fossil that is unclaimed by any extension currently in use"""
 
     _snapshots: Dict[str, "Snapshot"] = attr.ib(default=SNAPSHOTS_UNKNOWN, init=False)
 

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -5,6 +5,7 @@ from abc import (
     abstractmethod,
 )
 from difflib import ndiff
+from gettext import gettext
 from itertools import zip_longest
 from typing import (
     TYPE_CHECKING,
@@ -124,17 +125,21 @@ class SnapshotFossilizer(ABC):
         self._pre_write(data=data, index=index)
         snapshot_location = self.get_location(index=index)
         if not self.test_location.matches_snapshot_location(snapshot_location):
-            warning_msg = f"""
-            Can not relate snapshot location '{snapshot_location}' to the test location.
-            Consider adding '{self.test_location.filename}' to the generated location.
-            """
+            warning_msg = gettext(
+                """
+                Can not relate snapshot location '{}' to the test location.
+                Consider adding '{}' to the generated location.
+                """
+            ).format(snapshot_location, self.test_location.filename)
             warnings.warn(warning_msg)
         snapshot_name = self.get_snapshot_name(index=index)
         if not self.test_location.matches_snapshot_name(snapshot_name):
-            warning_msg = f"""
-            Can not relate snapshot name '{snapshot_name}' to the test location.
-            Consider adding '{self.test_location.testname}' to the generated name.
-            """
+            warning_msg = gettext(
+                """
+                Can not relate snapshot name '{}' to the test location.
+                Consider adding '{}' to the generated name.
+                """
+            ).format(snapshot_name, self.test_location.testname)
             warnings.warn(warning_msg)
         snapshot_fossil = SnapshotFossil(location=snapshot_location)
         snapshot_fossil.add(Snapshot(name=snapshot_name, data=data))

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -127,8 +127,8 @@ class SnapshotFossilizer(ABC):
         if not self.test_location.matches_snapshot_location(snapshot_location):
             warning_msg = gettext(
                 """
-                Can not relate snapshot location '{}' to the test location.
-                Consider adding '{}' to the generated location.
+Can not relate snapshot location '{}' to the test location.
+Consider adding '{}' to the generated location.
                 """
             ).format(snapshot_location, self.test_location.filename)
             warnings.warn(warning_msg)
@@ -136,8 +136,8 @@ class SnapshotFossilizer(ABC):
         if not self.test_location.matches_snapshot_name(snapshot_name):
             warning_msg = gettext(
                 """
-                Can not relate snapshot name '{}' to the test location.
-                Consider adding '{}' to the generated name.
+Can not relate snapshot name '{}' to the test location.
+Consider adding '{}' to the generated name.
                 """
             ).format(snapshot_name, self.test_location.testname)
             warnings.warn(warning_msg)

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -126,19 +126,15 @@ class SnapshotFossilizer(ABC):
         snapshot_location = self.get_location(index=index)
         if not self.test_location.matches_snapshot_location(snapshot_location):
             warning_msg = gettext(
-                """
-Can not relate snapshot location '{}' to the test location.
-Consider adding '{}' to the generated location.
-                """
+                "\nCan not relate snapshot location '{}' to the test location."
+                "\nConsider adding '{}' to the generated location."
             ).format(snapshot_location, self.test_location.filename)
             warnings.warn(warning_msg)
         snapshot_name = self.get_snapshot_name(index=index)
         if not self.test_location.matches_snapshot_name(snapshot_name):
             warning_msg = gettext(
-                """
-Can not relate snapshot name '{}' to the test location.
-Consider adding '{}' to the generated name.
-                """
+                "\nCan not relate snapshot name '{}' to the test location."
+                "\nConsider adding '{}' to the generated name."
             ).format(snapshot_name, self.test_location.testname)
             warnings.warn(warning_msg)
         snapshot_fossil = SnapshotFossil(location=snapshot_location)

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -123,6 +123,12 @@ class SnapshotFossilizer(ABC):
         """
         self._pre_write(data=data, index=index)
         snapshot_location = self.get_location(index=index)
+        if not self.test_location.matches_snapshot_location(snapshot_location):
+            warning_msg = f"""
+            Can not relate snapshot location '{snapshot_location}' to the test location.
+            Consider adding '{self.test_location.filename}' to the generated location.
+            """
+            warnings.warn(warning_msg)
         snapshot_name = self.get_snapshot_name(index=index)
         if not self.test_location.matches_snapshot_name(snapshot_name):
             warning_msg = f"""
@@ -182,7 +188,7 @@ class SnapshotFossilizer(ABC):
 
     @property
     def _dirname(self) -> str:
-        test_dirname = os.path.dirname(self.test_location.filename)
+        test_dirname = os.path.dirname(self.test_location.filepath)
         return os.path.join(test_dirname, SNAPSHOT_DIRNAME)
 
     @property
@@ -192,7 +198,7 @@ class SnapshotFossilizer(ABC):
 
     def _get_file_basename(self, *, index: int) -> str:
         """Returns file basename without extension. Used to create full filepath."""
-        return f"{os.path.splitext(os.path.basename(self.test_location.filename))[0]}"
+        return self.test_location.filename
 
     def __ensure_snapshot_dir(self, *, index: int) -> None:
         """

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -43,9 +43,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     @property
     def _dirname(self) -> str:
         original_dirname = super(SingleFileSnapshotExtension, self)._dirname
-        file_basename = os.path.basename(str(self.test_location.filename))
-        sub_dirname = os.path.splitext(file_basename)[0]
-        return os.path.join(original_dirname, sub_dirname)
+        return os.path.join(original_dirname, self.test_location.filename)
 
     def _read_snapshot_fossil(self, *, snapshot_location: str) -> "SnapshotFossil":
         snapshot_fossil = SnapshotFossil(location=snapshot_location)

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -1,3 +1,4 @@
+import os
 from typing import (
     Any,
     Optional,
@@ -7,7 +8,7 @@ from typing import (
 class TestLocation(object):
     def __init__(self, node: Any):
         self._node = node
-        self.filename = self._node.fspath
+        self.filepath = self._node.fspath
         self.modulename = self._node.obj.__module__
         self.methodname = self._node.obj.__name__
         self.nodename = getattr(self._node, "name", None)
@@ -18,7 +19,14 @@ class TestLocation(object):
         classes = self._node.obj.__qualname__.split(".")[:-1]
         return ".".join(classes) if classes else None
 
+    @property
+    def filename(self) -> str:
+        return str(os.path.splitext(os.path.basename(self.filepath))[0])
+
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
         matches_basemethod = str(self.methodname) in snapshot_name
         matches_testnode = snapshot_name in str(self.nodename)
         return matches_basemethod or matches_testnode
+
+    def matches_snapshot_location(self, snapshot_location: str) -> bool:
+        return self.filename in snapshot_location

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -49,16 +49,9 @@ class SnapshotReport(object):
     updated: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
     used: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
 
-    def filter_fossils(self, item: "SnapshotFossil") -> bool:
-        if not self.ran_items or not self.is_providing_paths:
-            return True
-
-        target_snaps = {snap.location for snap in self.used}
-
-        return item.location in target_snaps
-
     def __attrs_post_init__(self) -> None:
         for assertion in self.assertions:
+            self.discovered.merge(assertion.extension.discover_snapshots())
             for result in assertion.executions.values():
                 snapshot_fossil = SnapshotFossil(location=result.snapshot_location)
                 snapshot_fossil.add(
@@ -73,14 +66,6 @@ class SnapshotReport(object):
                     self.matched.update(snapshot_fossil)
                 else:
                     self.failed.update(snapshot_fossil)
-
-            discovered_snaps = assertion.extension.discover_snapshots()
-            filtered_snaps = {
-                snap.location: snap
-                for snap in discovered_snaps
-                if self.filter_fossils(snap)
-            }
-            self.discovered.merge(SnapshotFossils(filtered_snaps))
 
     @property
     def num_created(self) -> int:
@@ -114,17 +99,34 @@ class SnapshotReport(object):
         ):
             snapshot_location = unused_snapshot_fossil.location
             if self.ran_all_collected_tests:
+                if self.is_providing_paths and not any(
+                    TestLocation(node).matches_snapshot_location(snapshot_location)
+                    for node in self.ran_items
+                ):
+                    continue
                 unused_snapshots = {*unused_snapshot_fossil}
                 mark_for_removal = snapshot_location not in self.used
             else:
-                unused_snapshots = {
-                    snapshot
-                    for snapshot in unused_snapshot_fossil
-                    if any(
-                        TestLocation(node).matches_snapshot_name(snapshot.name)
-                        for node in self.ran_items
-                    )
-                }
+                if self.is_providing_paths:
+                    unused_snapshots = {
+                        snapshot
+                        for snapshot in unused_snapshot_fossil
+                        if any(
+                            TestLocation(node).matches_snapshot_location(
+                                snapshot_location
+                            )
+                            for node in self.ran_items
+                        )
+                    }
+                else:
+                    unused_snapshots = {
+                        snapshot
+                        for snapshot in unused_snapshot_fossil
+                        if any(
+                            TestLocation(node).matches_snapshot_name(snapshot.name)
+                            for node in self.ran_items
+                        )
+                    }
                 mark_for_removal = False
 
             if unused_snapshots:

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -107,26 +107,14 @@ class SnapshotReport(object):
                 unused_snapshots = {*unused_snapshot_fossil}
                 mark_for_removal = snapshot_location not in self.used
             else:
-                if self.is_providing_paths:
-                    unused_snapshots = {
-                        snapshot
-                        for snapshot in unused_snapshot_fossil
-                        if any(
-                            TestLocation(node).matches_snapshot_location(
-                                snapshot_location
-                            )
-                            for node in self.ran_items
-                        )
-                    }
-                else:
-                    unused_snapshots = {
-                        snapshot
-                        for snapshot in unused_snapshot_fossil
-                        if any(
-                            TestLocation(node).matches_snapshot_name(snapshot.name)
-                            for node in self.ran_items
-                        )
-                    }
+                unused_snapshots = {
+                    snapshot
+                    for snapshot in unused_snapshot_fossil
+                    if any(
+                        TestLocation(node).matches_snapshot_name(snapshot.name)
+                        for node in self.ran_items
+                    )
+                }
                 mark_for_removal = False
 
             if unused_snapshots:

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -98,12 +98,13 @@ class SnapshotReport(object):
             self.discovered, self.used
         ):
             snapshot_location = unused_snapshot_fossil.location
+            if self.is_providing_paths and not any(
+                TestLocation(node).matches_snapshot_location(snapshot_location)
+                for node in self.ran_items
+            ):
+                continue
+
             if self.ran_all_collected_tests:
-                if self.is_providing_paths and not any(
-                    TestLocation(node).matches_snapshot_location(snapshot_location)
-                    for node in self.ran_items
-                ):
-                    continue
                 unused_snapshots = {*unused_snapshot_fossil}
                 mark_for_removal = snapshot_location not in self.used
             else:

--- a/tests/examples/test_custom_snapshot_directory.py
+++ b/tests/examples/test_custom_snapshot_directory.py
@@ -23,7 +23,7 @@ DIFFERENT_DIRECTORY = "__snaps_example__"
 class DifferentDirectoryExtension(AmberSnapshotExtension):
     @property
     def _dirname(self) -> str:
-        test_dirname = os.path.dirname(self.test_location.filename)
+        test_dirname = os.path.dirname(self.test_location.filepath)
         return os.path.join(test_dirname, DIFFERENT_DIRECTORY)
 
 

--- a/tests/test_integration_custom.py
+++ b/tests/test_integration_custom.py
@@ -34,6 +34,9 @@ def testcases(testdir):
             def delete_snapshots(self, **kwargs):
                 pass
 
+            def _get_file_basename(self, *, index = 0):
+                return self.test_location.filename[::-1]
+
 
         @pytest.fixture
         def snapshot_custom(snapshot):
@@ -57,5 +60,7 @@ def test_warns_on_snapshot_name(testdir, testcases):
     result_stdout = clean_output(result.stdout.str())
     assert "2 snapshots generated" in result_stdout
     assert "Warning:" in result_stdout
+    assert "Can not relate snapshot name" in result_stdout
+    assert "Can not relate snapshot location" in result_stdout
     assert "test_passed_custom" in result_stdout
     assert result.ret == 0

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -307,6 +307,26 @@ def test_unused_snapshots_ignored_if_not_targeted_when_targeting_specific_testfi
     assert os.path.isfile("__snapshots__/other_snapfile.ambr")
 
 
+def test_unused_snapshots_cleaned_up_when_targeting_specific_testfiles(stubs,):
+    _, testdir, tests, _ = stubs
+    testdir.makepyfile(
+        test_file=(
+            """
+            def test_add_fixture_to_run_syrupy(snapshot):
+                assert True
+            """
+        )
+    )
+    testdir.makefile(
+        ".ambr", **{"__snapshots__/other_snapfile": ""},
+    )
+    result = testdir.runpytest("-v", "--snapshot-update", "test_file.py")
+    result_stdout = clean_output(result.stdout.str())
+    assert "7 unused snapshots deleted" in result_stdout
+    assert result.ret == 0
+    assert os.path.isfile("__snapshots__/other_snapfile.ambr")
+
+
 def test_removed_snapshots(stubs):
     _, testdir, tests, filepath = stubs
     assert os.path.isfile(filepath)

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -360,7 +360,7 @@ def test_unused_snapshots_cleaned_up_when_targeting_specific_testfiles(stubs):
     testdir.makepyfile(
         test_file=(
             """
-            def test_add_fixture_to_run_syrupy(snapshot):
+            def test_used(snapshot):
                 assert True
             """
         )
@@ -401,15 +401,14 @@ def test_removed_snapshot_fossil(stubs):
 
 def test_removed_empty_snapshot_fossil_only(stubs):
     _, testdir, _, filepath = stubs
-    empty_filepath = os.path.join(os.path.dirname(filepath), "test_empty.ambr")
-    with open(empty_filepath, "w") as empty_snapfile:
-        empty_snapfile.write("")
+    testdir.makefile(".ambr", **{"__snapshots__/test_empty": ""})
+    empty_filepath = os.path.join(testdir.tmpdir, "__snapshots__/test_empty.ambr")
     assert os.path.isfile(empty_filepath)
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
     assert os.path.relpath(filepath) not in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
-    assert "empty snapshot" in result_stdout
+    assert "snapshot fossil" in result_stdout
     assert os.path.relpath(empty_filepath) in result_stdout
     assert result.ret == 0
     assert os.path.isfile(filepath)
@@ -418,9 +417,8 @@ def test_removed_empty_snapshot_fossil_only(stubs):
 
 def test_removed_hanging_snapshot_fossil(stubs):
     _, testdir, _, filepath = stubs
-    hanging_filepath = os.path.join(os.path.dirname(filepath), "test_hanging.abc")
-    with open(hanging_filepath, "w") as empty_snapfile:
-        empty_snapfile.write("some dummy content")
+    testdir.makefile(".abc", **{"__snapshots__/test_hanging": ""})
+    hanging_filepath = os.path.join(testdir.tmpdir, "__snapshots__/test_hanging.abc")
     assert os.path.isfile(hanging_filepath)
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -408,7 +408,7 @@ def test_removed_empty_snapshot_fossil_only(stubs):
     result_stdout = clean_output(result.stdout.str())
     assert os.path.relpath(filepath) not in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
-    assert "snapshot fossil" in result_stdout
+    assert "empty snapshot" in result_stdout
     assert os.path.relpath(empty_filepath) in result_stdout
     assert result.ret == 0
     assert os.path.isfile(filepath)

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -28,6 +28,7 @@ def collection(testdir):
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
     assert "4 snapshots generated" in result_stdout
+    testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": ""})
     return testdir
 
 
@@ -49,9 +50,9 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
     assert "1 snapshot passed" in result_stdout
     assert "1 snapshot updated" in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
-    assert os.path.isfile(
-        os.path.join(collection.tmpdir, "__snapshots__/test_not_collected.ambr")
-    )
+    snapshot_path = [collection.tmpdir, "__snapshots__"]
+    assert os.path.isfile(os.path.join(*snapshot_path, "test_not_collected.ambr"))
+    assert os.path.isfile(os.path.join(*snapshot_path, "other_snapfile.ambr"))
 
 
 def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection):
@@ -72,9 +73,9 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection):
     assert "1 snapshot passed" in result_stdout
     assert "1 snapshot updated" in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
-    assert os.path.isfile(
-        os.path.join(collection.tmpdir, "__snapshots__/test_not_collected.ambr")
-    )
+    snapshot_path = [collection.tmpdir, "__snapshots__"]
+    assert os.path.isfile(os.path.join(*snapshot_path, "test_not_collected.ambr"))
+    assert os.path.isfile(os.path.join(*snapshot_path, "other_snapfile.ambr"))
 
 
 def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(collection):
@@ -95,9 +96,9 @@ def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(collection):
     assert "2 snapshots passed" in result_stdout
     assert "snapshot updated" not in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
-    assert os.path.isfile(
-        os.path.join(collection.tmpdir, "__snapshots__/test_not_collected.ambr")
-    )
+    snapshot_path = [collection.tmpdir, "__snapshots__"]
+    assert os.path.isfile(os.path.join(*snapshot_path, "test_not_collected.ambr"))
+    assert os.path.isfile(os.path.join(*snapshot_path, "other_snapfile.ambr"))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

- Fixes issue where snapshot files were not cleaned up when running specific test files
- Fixes issue where targeting specific test nodes in a test file was not supported
- Fixes issue where targeting specific test modules using pyargs was not supported

## Related Issues

N/A

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I have updated the CHANGELOG.md.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
