### PR TITLE
Replace all instances of `os.path` with `pathlib` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 ## Master (Unreleased)
 
+- Conversion of all `os.path` and `os.walk` calls to use `pathlib` instead, setting `pathlib` as the new preferred way of doing path operations (#130)
+
 - Up to date with releases.
 
 ## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ These are mostly guidelines, not rules. Use your best judgment, and feel free to
 
 - [Commit Messages](#commit-messages)
 - [Code Styleguide](#code-styleguide)
+- [`pathlib` over `os.path`](#usage-of-pathlib)
 
 [Additional Notes](#additional-notes)
 
@@ -100,6 +101,10 @@ A linter is available to catch most of our styling concerns.
 This is provided in a pre-commit hook when setting up [local development](#local-development).
 
 You can also run `inv lint --fix` to see and solve what issues it can.
+
+### Usage of Pathlib
+
+`pathlib` is the preferred library when dealing with path operations. Some [documentation](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module) is available to help translate `os.path`-type calls to `pathlib` calls. Documentation on `pathlib`'s API is also available on the same page.
 
 ## Additional Notes
 

--- a/src/syrupy/extensions/amber.py
+++ b/src/syrupy/extensions/amber.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from types import GeneratorType
 from typing import (
     TYPE_CHECKING,
@@ -296,7 +296,7 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
         if snapshot_fossil_to_update.has_snapshots:
             DataSerializer.write_file(snapshot_fossil_to_update)
         else:
-            os.remove(snapshot_location)
+            Path(snapshot_location).unlink()
 
     @property
     def _file_extension(self) -> str:

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from abc import (
     ABC,
@@ -7,6 +6,7 @@ from abc import (
 from difflib import ndiff
 from gettext import gettext
 from itertools import zip_longest
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -69,7 +69,7 @@ class SnapshotFossilizer(ABC):
     def get_location(self, *, index: int) -> str:
         """Returns full location where snapshot data is stored."""
         basename = self._get_file_basename(index=index)
-        return os.path.join(self._dirname, f"{basename}.{self._file_extension}")
+        return str(Path(self._dirname).joinpath(f"{basename}.{self._file_extension}"))
 
     def is_snapshot_location(self, *, location: str) -> bool:
         """Checks if supplied location is valid for this snapshot extension"""
@@ -189,8 +189,8 @@ class SnapshotFossilizer(ABC):
 
     @property
     def _dirname(self) -> str:
-        test_dirname = os.path.dirname(self.test_location.filepath)
-        return os.path.join(test_dirname, SNAPSHOT_DIRNAME)
+        test_dir = Path(self.test_location.filepath).parent
+        return str(test_dir.joinpath(SNAPSHOT_DIRNAME))
 
     @property
     @abstractmethod
@@ -206,7 +206,7 @@ class SnapshotFossilizer(ABC):
         Ensures the folder path for the snapshot file exists.
         """
         try:
-            os.makedirs(os.path.dirname(self.get_location(index=index)))
+            Path(self.get_location(index=index)).parent.mkdir(parents=True)
         except FileExistsError:
             pass
 

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -1,6 +1,6 @@
-import os
 import re
 from gettext import gettext
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Optional,
@@ -31,7 +31,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     def delete_snapshots(
         self, *, snapshot_location: str, snapshot_names: Set[str]
     ) -> None:
-        os.remove(snapshot_location)
+        Path(snapshot_location).unlink()
 
     @property
     def _file_extension(self) -> str:
@@ -43,13 +43,11 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     @property
     def _dirname(self) -> str:
         original_dirname = super(SingleFileSnapshotExtension, self)._dirname
-        return os.path.join(original_dirname, self.test_location.filename)
+        return str(Path(original_dirname).joinpath(self.test_location.filename))
 
     def _read_snapshot_fossil(self, *, snapshot_location: str) -> "SnapshotFossil":
         snapshot_fossil = SnapshotFossil(location=snapshot_location)
-        snapshot_fossil.add(
-            Snapshot(name=os.path.splitext(os.path.basename(snapshot_location))[0])
-        )
+        snapshot_fossil.add(Snapshot(name=Path(snapshot_location).stem))
         return snapshot_fossil
 
     def _read_snapshot_data_from_location(

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import (
     Any,
     Optional,
@@ -21,7 +21,7 @@ class TestLocation(object):
 
     @property
     def filename(self) -> str:
-        return str(os.path.splitext(os.path.basename(self.filepath))[0])
+        return Path(self.filepath).stem
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
         matches_basemethod = str(self.methodname) in snapshot_name

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -1,8 +1,8 @@
-import os
 from gettext import (
     gettext,
     ngettext,
 )
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -181,7 +181,7 @@ class SnapshotReport(object):
                 for snapshot_fossil in self.unused:
                     filepath = snapshot_fossil.location
                     snapshots = (snapshot.name for snapshot in snapshot_fossil)
-                    path_to_file = os.path.relpath(filepath, self.base_dir)
+                    path_to_file = str(Path(filepath).relative_to(self.base_dir))
                     deleted_snapshots = ", ".join(map(bold, sorted(snapshots)))
                     yield warning_style(gettext("Deleted {} ({})")).format(
                         deleted_snapshots, path_to_file

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -91,4 +91,4 @@ class SnapshotSession:
                     },
                 )
             elif snapshot_location not in used_snapshot_fossils:
-                os.remove(snapshot_location)
+                Path(snapshot_location).unlink()

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -1,18 +1,16 @@
-import os
+from pathlib import Path
 from typing import Generator
 
 from .constants import SNAPSHOT_DIRNAME
 
 
-def in_snapshot_dir(path: str) -> bool:
-    parts = path.split(os.path.sep)
-    return SNAPSHOT_DIRNAME in parts
+def in_snapshot_dir(path: Path) -> bool:
+    return SNAPSHOT_DIRNAME in path.parts
 
 
 def walk_snapshot_dir(root: str) -> Generator[str, None, None]:
-    for (dirpath, _, filenames) in os.walk(root):
-        if not in_snapshot_dir(dirpath):
+    for filepath in Path(root).rglob("*"):
+        if not in_snapshot_dir(filepath):
             continue
-        for filename in filenames:
-            if not filename.startswith("."):
-                yield os.path.join(dirpath, filename)
+        if not filepath.name.startswith(".") and filepath.is_file():
+            yield str(filepath)

--- a/tests/examples/test_custom_snapshot_directory.py
+++ b/tests/examples/test_custom_snapshot_directory.py
@@ -10,7 +10,7 @@ root conftest.py file, it is equivalent to globally overriding
 the default snapshot directory.
 """
 
-import os
+from pathlib import Path
 
 import pytest
 
@@ -23,8 +23,9 @@ DIFFERENT_DIRECTORY = "__snaps_example__"
 class DifferentDirectoryExtension(AmberSnapshotExtension):
     @property
     def _dirname(self) -> str:
-        test_dirname = os.path.dirname(self.test_location.filepath)
-        return os.path.join(test_dirname, DIFFERENT_DIRECTORY)
+        return str(
+            Path(self.test_location.filepath).parent.joinpath(DIFFERENT_DIRECTORY)
+        )
 
 
 @pytest.fixture

--- a/tests/test_extension_single_file.py
+++ b/tests/test_extension_single_file.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -21,14 +21,14 @@ def snapshot_single(snapshot):
 
 def test_does_not_write_non_binary(testdir, snapshot_single: "SnapshotAssertion"):
     snapshot_fossil = SnapshotFossil(
-        location=os.path.join(testdir.tmpdir, "snapshot_fossil.raw"),
+        location=str(Path(testdir.tmpdir).joinpath("snapshot_fossil.raw")),
     )
     snapshot_fossil.add(Snapshot(name="snapshot_name", data="non binary data"))
     with pytest.raises(TypeError, match="Expected 'bytes', got 'str'"):
         snapshot_single.extension._write_snapshot_fossil(
             snapshot_fossil=snapshot_fossil
         )
-    assert not os.path.exists(snapshot_fossil.location)
+    assert not Path(snapshot_fossil.location).exists()
 
 
 class TestClass:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -7,12 +7,12 @@ from syrupy.utils import walk_snapshot_dir
 
 def makefiles(testdir, filetree, root=""):
     for filename, contents in filetree.items():
-        filepath = os.path.join(root, filename)
+        filepath = Path(root).joinpath(filename)
         if isinstance(contents, dict):
             testdir.mkdir(filepath)
             makefiles(testdir, contents, filepath)
         else:
-            name, ext = os.path.splitext(filepath)
+            name, ext = str(filepath.with_name(filepath.stem)), filepath.suffix
             testdir.makefile(ext, **{name: contents})
 
 
@@ -36,7 +36,6 @@ def testfiles(testdir):
 
 def test_walk_dir_skips_non_snapshot_path(testfiles):
     _, testdir = testfiles
-    assert {os.path.relpath(p) for p in walk_snapshot_dir(testdir.tmpdir)} == {
-        "__snapshots__/snapfile1.ambr",
-        "__snapshots__/snapfolder/snapfile2.svg",
-    }
+    assert {
+        str(Path(p).relative_to(Path.cwd())) for p in walk_snapshot_dir(testdir.tmpdir)
+    } == {"__snapshots__/snapfile1.ambr", "__snapshots__/snapfolder/snapfile2.svg"}


### PR DESCRIPTION
## Description

As explained in #121, `pathlib` is the newer, py3 successor to `os.path` and provides an arguably friendlier interface to system paths than `os.path` does. Additionally, it is built to be platform agnostic, which is a hoot.

## Related Issues

This resolves #121 and replaces all instances of `os.path` with `pathlib.Path` methods. This encompasses both the source and the test code.

## Checklist

**Since the changes are entirely internal, this doesn't add any more tests (all present tests passing is sufficient to establish correctness and equivalency to the previous `os.path` patterns).**

- ~[ ] This PR has sufficient test coverage.~
- ~[ ] I have updated the CHANGELOG.md.~