### PR TITLE
Fix faulty matching test node to snapshot name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 - Conversion of all `os.path` and `os.walk` calls to use `pathlib` instead, setting `pathlib` as the new preferred way of doing path operations (#130)
 - Fix bug where snapshot diffs were erroneously printed (#135)
-- Fix bug where snapshot name were incorrectly matching tests (#136)
+- Fix bug where snapshot names were incorrectly matching tests (#136)
 - Fix bug where deleted snapshots where incorrectly colored (#136)
 
 ## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 - Conversion of all `os.path` and `os.walk` calls to use `pathlib` instead, setting `pathlib` as the new preferred way of doing path operations (#130)
 - Fix bug where snapshot diffs were erroneously printed (#135)
 - Fix bug where snapshot name were incorrectly matching tests (#136)
+- Fix bug where deleted snapshots where incorrectly colored (#136)
 
 ## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 
 - Conversion of all `os.path` and `os.walk` calls to use `pathlib` instead, setting `pathlib` as the new preferred way of doing path operations (#130)
 - Fix bug where snapshot diffs were erroneously printed (#135)
+- Fix bug where snapshot name were incorrectly matching tests (#136)
 
 ## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)
 

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -23,11 +23,11 @@ class TestLocation(object):
     def filename(self) -> str:
         return Path(self.filepath).stem
 
-    def __pick_id(self, name: str) -> str:
+    def __valid_id(self, name: str) -> str:
         return "".join(c for c in name if c.isidentifier())
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
-        return self.__pick_id(str(self.methodname)) == self.__pick_id(snapshot_name)
+        return self.__valid_id(str(self.methodname)) == self.__valid_id(snapshot_name)
 
     def matches_snapshot_location(self, snapshot_location: str) -> bool:
         return self.filename in snapshot_location

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -24,9 +24,12 @@ class TestLocation(object):
         return Path(self.filepath).stem
 
     def __valid_id(self, name: str) -> str:
-        [valid_id, *other] = name
-        while valid_id.isidentifier() and other:
-            valid_id += other.pop()
+        [valid_id, *rest] = name
+        while rest:
+            new_valid_id = f"{valid_id}{rest.pop(0)}"
+            if not new_valid_id.isidentifier():
+                break
+            valid_id = new_valid_id
         return valid_id
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -23,15 +23,11 @@ class TestLocation(object):
     def filename(self) -> str:
         return Path(self.filepath).stem
 
-    def __matches_snapshot_name(self, var_name: str, snapshot_name: str) -> bool:
-        if var_name.isidentifier():
-            return var_name in snapshot_name
-        return snapshot_name in var_name
+    def __pick_id(self, name: str) -> str:
+        return "".join(c for c in name if c.isidentifier())
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
-        return self.__matches_snapshot_name(
-            str(self.methodname), snapshot_name
-        ) or self.__matches_snapshot_name(str(self.nodename), snapshot_name)
+        return self.__pick_id(str(self.methodname)) == self.__pick_id(snapshot_name)
 
     def matches_snapshot_location(self, snapshot_location: str) -> bool:
         return self.filename in snapshot_location

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -24,7 +24,12 @@ class TestLocation(object):
         return Path(self.filepath).stem
 
     def __valid_id(self, name: str) -> str:
-        return "".join(c for c in name if c.isidentifier())
+        valid_id = []
+        for c in name:
+            if not c.isidentifier():
+                break
+            valid_id.append(c)
+        return "".join(valid_id)
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
         return self.__valid_id(str(self.methodname)) == self.__valid_id(snapshot_name)

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -24,12 +24,10 @@ class TestLocation(object):
         return Path(self.filepath).stem
 
     def __valid_id(self, name: str) -> str:
-        valid_id = []
-        for c in name:
-            if not c.isidentifier():
-                break
-            valid_id.append(c)
-        return "".join(valid_id)
+        [valid_id, *other] = name
+        while valid_id.isidentifier() and other:
+            valid_id += other.pop()
+        return valid_id
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
         return self.__valid_id(str(self.methodname)) == self.__valid_id(snapshot_name)

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -23,10 +23,15 @@ class TestLocation(object):
     def filename(self) -> str:
         return Path(self.filepath).stem
 
+    def __matches_snapshot_name(self, var_name: str, snapshot_name: str) -> bool:
+        if var_name.isidentifier():
+            return var_name in snapshot_name
+        return snapshot_name in var_name
+
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
-        matches_basemethod = str(self.methodname) in snapshot_name
-        matches_testnode = snapshot_name in str(self.nodename)
-        return matches_basemethod or matches_testnode
+        return self.__matches_snapshot_name(
+            str(self.methodname), snapshot_name
+        ) or self.__matches_snapshot_name(str(self.nodename), snapshot_name)
 
     def matches_snapshot_location(self, snapshot_location: str) -> bool:
         return self.filename in snapshot_location

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -183,7 +183,7 @@ class SnapshotReport(object):
                     snapshots = (snapshot.name for snapshot in snapshot_fossil)
                     path_to_file = str(Path(filepath).relative_to(self.base_dir))
                     deleted_snapshots = ", ".join(map(bold, sorted(snapshots)))
-                    yield warning_style(gettext("Deleted {} ({})")).format(
+                    yield warning_style(gettext("Deleted")) + " {} ({})".format(
                         deleted_snapshots, path_to_file
                     )
             else:

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -12,8 +12,9 @@ def collection(testdir):
             """
             import pytest
 
+            @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, 2, 3])
-            def test_name1(snapshot, actual):
+            def test_name(snapshot, actual):
                 assert snapshot == actual
             """
         ),
@@ -21,8 +22,9 @@ def collection(testdir):
             """
             import pytest
 
+            @pytest.mark.not_collected
             @pytest.mark.parametrize("actual", [1, 2, 3])
-            def test_name(snapshot, actual):
+            def test_name1(snapshot, actual):
                 assert snapshot == actual
             """
         ),
@@ -43,7 +45,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
 
             @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, "2"])
-            def test_name1(snapshot, actual):
+            def test_name(snapshot, actual):
                 assert snapshot == actual
             """
         ),
@@ -55,7 +57,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
     assert "1 snapshot updated" in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
     snapshot_path = [collection.tmpdir, "__snapshots__"]
-    assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
+    assert Path(*snapshot_path).joinpath("test_collected.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 
@@ -66,13 +68,13 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection):
             import pytest
 
             @pytest.mark.parametrize("actual", [1, "2"])
-            def test_name1(snapshot, actual):
+            def test_name(snapshot, actual):
                 assert snapshot == actual
             """
         ),
     }
     collection.makepyfile(**updated_tests)
-    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_name1")
+    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_name[")
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot passed" in result_stdout
     assert "1 snapshot updated" in result_stdout
@@ -89,13 +91,13 @@ def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(collection):
             import pytest
 
             @pytest.mark.parametrize("actual", [1, 2])
-            def test_name1(snapshot, actual):
+            def test_name(snapshot, actual):
                 assert snapshot == actual
             """
         ),
     }
     collection.makepyfile(**updated_tests)
-    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_name1")
+    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_name[")
     result_stdout = clean_output(result.stdout.str())
     assert "2 snapshots passed" in result_stdout
     assert "snapshot updated" not in result_stdout

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -17,9 +17,9 @@ def collection(testdir):
                 assert snapshot == actual
             """
         ),
-        "test_not_collected": (
+        "test_collect": (
             """
-            def test_not_collected(snapshot):
+            def test_collect(snapshot):
                 assert snapshot == "hello"
             """
         ),
@@ -51,7 +51,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
     assert "1 snapshot updated" in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
     snapshot_path = [collection.tmpdir, "__snapshots__"]
-    assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
+    assert Path(*snapshot_path).joinpath("test_collect.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 
@@ -74,7 +74,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection):
     assert "1 snapshot updated" in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
     snapshot_path = [collection.tmpdir, "__snapshots__"]
-    assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
+    assert Path(*snapshot_path).joinpath("test_collect.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 
@@ -97,7 +97,7 @@ def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(collection):
     assert "snapshot updated" not in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
     snapshot_path = [collection.tmpdir, "__snapshots__"]
-    assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
+    assert Path(*snapshot_path).joinpath("test_collect.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -12,7 +12,6 @@ def collection(testdir):
             """
             import pytest
 
-            @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, 2, 3])
             def test_collected(snapshot, actual):
                 assert snapshot == actual

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -20,19 +20,15 @@ def collection(testdir):
         ),
         "test_not_collected": (
             """
-            import pytest
-
-            @pytest.mark.not_collected
-            @pytest.mark.parametrize("actual", [1, 2, 3])
-            def test_collected1(snapshot, actual):
-                assert snapshot == actual
+            def test_collected1(snapshot):
+                assert snapshot == "hello"
             """
         ),
     }
     testdir.makepyfile(**tests)
     result = testdir.runpytest("-v", "--snapshot-update")
     result_stdout = clean_output(result.stdout.str())
-    assert "6 snapshots generated" in result_stdout
+    assert "4 snapshots generated" in result_stdout
     testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": ""})
     return testdir
 

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -39,19 +39,19 @@ def collection(testdir):
 
 def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
     updated_tests = {
-        "test_not_collected": (
+        "test_collected": (
             """
             import pytest
 
-            @pytest.mark.not_collected
+            @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, "2"])
-            def test_name(snapshot, actual):
+            def test_name1(snapshot, actual):
                 assert snapshot == actual
             """
         ),
     }
     collection.makepyfile(**updated_tests)
-    result = collection.runpytest("-v", "--snapshot-update", "-m", "not_collected")
+    result = collection.runpytest("-v", "--snapshot-update", "-m", "collected")
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot passed" in result_stdout
     assert "1 snapshot updated" in result_stdout

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -57,7 +57,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
     assert "1 snapshot updated" in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
     snapshot_path = [collection.tmpdir, "__snapshots__"]
-    assert Path(*snapshot_path).joinpath("test_collected.ambr").exists()
+    assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -38,7 +38,6 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
             """
             import pytest
 
-            @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, "2"])
             def test_collected(snapshot, actual):
                 assert snapshot == actual
@@ -46,7 +45,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
         ),
     }
     collection.makepyfile(**updated_tests)
-    result = collection.runpytest("-v", "--snapshot-update", "-m", "collected")
+    result = collection.runpytest("-v", "--snapshot-update", "-m", "parametrize")
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot passed" in result_stdout
     assert "1 snapshot updated" in result_stdout

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -14,7 +14,7 @@ def collection(testdir):
 
             @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, 2, 3])
-            def test_name(snapshot, actual):
+            def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
         ),
@@ -24,7 +24,7 @@ def collection(testdir):
 
             @pytest.mark.not_collected
             @pytest.mark.parametrize("actual", [1, 2, 3])
-            def test_name1(snapshot, actual):
+            def test_collected1(snapshot, actual):
                 assert snapshot == actual
             """
         ),
@@ -45,7 +45,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
 
             @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, "2"])
-            def test_name(snapshot, actual):
+            def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
         ),
@@ -57,7 +57,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
     assert "1 snapshot updated" in result_stdout
     assert "1 unused snapshot deleted" in result_stdout
     snapshot_path = [collection.tmpdir, "__snapshots__"]
-    assert Path(*snapshot_path).joinpath("test_collected.ambr").exists()
+    assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 
@@ -68,13 +68,13 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection):
             import pytest
 
             @pytest.mark.parametrize("actual", [1, "2"])
-            def test_name(snapshot, actual):
+            def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
         ),
     }
     collection.makepyfile(**updated_tests)
-    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_name[")
+    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_collected[")
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot passed" in result_stdout
     assert "1 snapshot updated" in result_stdout
@@ -91,13 +91,13 @@ def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(collection):
             import pytest
 
             @pytest.mark.parametrize("actual", [1, 2])
-            def test_name(snapshot, actual):
+            def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
         ),
     }
     collection.makepyfile(**updated_tests)
-    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_name[")
+    result = collection.runpytest("-v", "--snapshot-update", "-k", "test_collected[")
     result_stdout = clean_output(result.stdout.str())
     assert "2 snapshots passed" in result_stdout
     assert "snapshot updated" not in result_stdout

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -12,7 +12,6 @@ def collection(testdir):
             """
             import pytest
 
-            @pytest.mark.collected
             @pytest.mark.parametrize("actual", [1, 2, 3])
             def test_name1(snapshot, actual):
                 assert snapshot == actual
@@ -22,7 +21,6 @@ def collection(testdir):
             """
             import pytest
 
-            @pytest.mark.not_collected
             @pytest.mark.parametrize("actual", [1, 2, 3])
             def test_name(snapshot, actual):
                 assert snapshot == actual


### PR DESCRIPTION
## Description

Check if test node is in snapshot name when the test node is a valid identifier else check if the snapshot name is in the test node. This allows expanded tests like `test_parametrized` match `test_parametrized[a]` and `test_parametrized[b]`.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #134

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I have updated the CHANGELOG.md.

## Additional Comments

N/A