### PR TITLE
Filter out unused snapshots when selecting test nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 - Fix bug where snapshot diffs were erroneously printed (#135)
 - Fix bug where snapshot names were incorrectly matching tests (#136)
 - Fix bug where deleted snapshots where incorrectly colored (#136)
+- Fix bug where targeting specific test nodes did not filter out unused snapshots (#139)
 
 ## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -58,6 +58,10 @@ def __is_testpath(arg: str) -> bool:
     return not arg.startswith("-") and bool(glob.glob(arg.split("::")[0]))
 
 
+def __is_testnode(arg: str) -> bool:
+    return __is_testpath(arg) and "::" in arg
+
+
 def __is_testmodule(arg: str) -> bool:
     return arg == "--pyargs"
 
@@ -75,6 +79,9 @@ def pytest_sessionstart(session: Any) -> None:
         is_providing_paths=any(
             __is_testpath(arg) or __is_testmodule(arg)
             for arg in config.invocation_params.args
+        ),
+        is_providing_nodes=any(
+            __is_testnode(arg) for arg in config.invocation_params.args
         ),
     )
     session._syrupy.start()

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 @attr.s
-class AssertionResult(object):
+class AssertionResult:
     snapshot_location: str = attr.ib()
     snapshot_name: str = attr.ib()
     asserted_data: Optional["SerializedData"] = attr.ib()

--- a/src/syrupy/data.py
+++ b/src/syrupy/data.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 @attr.s(frozen=True)
-class Snapshot(object):
+class Snapshot:
     name: str = attr.ib()
     data: Optional["SerializedData"] = attr.ib(default=None)
 
@@ -35,7 +35,7 @@ class SnapshotUnknown(Snapshot):
 
 
 @attr.s
-class SnapshotFossil(object):
+class SnapshotFossil:
     """A collection of snapshots at a save location"""
 
     location: str = attr.ib()
@@ -90,7 +90,7 @@ class SnapshotUnknownFossil(SnapshotFossil):
 
 
 @attr.s
-class SnapshotFossils(object):
+class SnapshotFossils:
     _snapshot_fossils: Dict[str, "SnapshotFossil"] = attr.ib(factory=dict)
 
     def get(self, location: str) -> Optional["SnapshotFossil"]:

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 
-class TestLocation(object):
+class TestLocation:
     def __init__(self, node: Any):
         self._node = node
         self.filepath = self._node.fspath

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -34,12 +34,13 @@ if TYPE_CHECKING:
 
 
 @attr.s
-class SnapshotReport(object):
+class SnapshotReport:
     base_dir: str = attr.ib()
     all_items: Set[Any] = attr.ib()
     ran_items: Set[Any] = attr.ib()
     update_snapshots: bool = attr.ib()
     is_providing_paths: bool = attr.ib()
+    is_providing_nodes: bool = attr.ib()
     warn_unused_snapshots: bool = attr.ib()
     assertions: List["SnapshotAssertion"] = attr.ib()
     discovered: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
@@ -89,7 +90,7 @@ class SnapshotReport(object):
 
     @property
     def ran_all_collected_tests(self) -> bool:
-        return self.all_items == self.ran_items
+        return self.all_items == self.ran_items and not self.is_providing_nodes
 
     @property
     def unused(self) -> "SnapshotFossils":

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -8,6 +8,8 @@ from typing import (
     Set,
 )
 
+import attr
+
 from .constants import EXIT_STATUS_FAIL_UNUSED
 from .data import SnapshotFossils
 from .report import SnapshotReport
@@ -18,24 +20,18 @@ if TYPE_CHECKING:
     from .extensions.base import AbstractSyrupyExtension  # noqa: F401
 
 
+@attr.s
 class SnapshotSession:
-    def __init__(
-        self,
-        *,
-        warn_unused_snapshots: bool,
-        update_snapshots: bool,
-        base_dir: str,
-        is_providing_paths: bool,
-    ):
-        self.warn_unused_snapshots = warn_unused_snapshots
-        self.update_snapshots = update_snapshots
-        self.base_dir = base_dir
-        self.is_providing_paths: bool = is_providing_paths
-        self.report: Optional["SnapshotReport"] = None
-        self._all_items: Set[Any] = set()
-        self._ran_items: Set[Any] = set()
-        self._assertions: List["SnapshotAssertion"] = []
-        self._extensions: Dict[str, "AbstractSyrupyExtension"] = {}
+    base_dir: str = attr.ib()
+    update_snapshots: bool = attr.ib()
+    warn_unused_snapshots: bool = attr.ib()
+    is_providing_paths: bool = attr.ib()
+    is_providing_nodes: bool = attr.ib()
+    report: Optional["SnapshotReport"] = attr.ib(default=None)
+    _all_items: Set[Any] = attr.ib(factory=set)
+    _ran_items: Set[Any] = attr.ib(factory=set)
+    _assertions: List["SnapshotAssertion"] = attr.ib(factory=list)
+    _extensions: Dict[str, "AbstractSyrupyExtension"] = attr.ib(factory=dict)
 
     def start(self) -> None:
         self.report = None
@@ -54,6 +50,7 @@ class SnapshotSession:
             update_snapshots=self.update_snapshots,
             warn_unused_snapshots=self.warn_unused_snapshots,
             is_providing_paths=self.is_providing_paths,
+            is_providing_nodes=self.is_providing_nodes,
         )
         if self.report.num_unused:
             if self.update_snapshots:

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -287,7 +287,6 @@ def test_unused_snapshots_warning(stubs):
 
 
 def test_unused_snapshots_ignored_if_not_targeted_by_testnode_ids(testdir):
-    snapshot_file = Path(testdir.tmpdir, "__snapshots__", "test_file.ambr")
     testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": ""})
     testdir.makefile(
         ".py",
@@ -302,15 +301,15 @@ def test_unused_snapshots_ignored_if_not_targeted_by_testnode_ids(testdir):
         ),
     )
     testfile = Path(testdir.tmpdir, "test_life_uhh_finds_a_way.py")
-    testdir.runpytest("-v", "--snapshot-update")
+    testdir.runpytest(str(testfile), "-v", "--snapshot-update")
     result = testdir.runpytest(
         f"{testfile}::test_life_always_finds_a_way", "-v", "--snapshot-update"
     )
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot passed" in result_stdout
-    assert "unused" not in result_stdout
+    assert "snapshots unused" not in result_stdout
+    assert "snapshot unused" not in result_stdout
     assert result.ret == 0
-    assert Path(snapshot_file).exists()
     assert Path("__snapshots__/other_snapfile.ambr").exists()
 
 


### PR DESCRIPTION
## Description

Filters out unused snapshots when selecting tests nodes.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #138 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I have updated the CHANGELOG.md.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
