### PR TITLE
Show snapshot report after failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ From v1.0.0 onwards, this project adheres to [Semantic Versioning](https://semve
 - Fix bug where snapshot names were incorrectly matching tests (#136)
 - Fix bug where deleted snapshots where incorrectly colored (#136)
 - Fix bug where targeting specific test nodes did not filter out unused snapshots (#139)
+- Fix bug where snapshot report was printed out before the pytest report (#144)
 
 ## [v0.3.2](https://github.com/tophat/syrupy/compare/v0.3.1...v0.3.2)
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -136,7 +136,7 @@ def pytest_terminal_summary(
     Add syrupy report to pytest.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_terminal_summary
     """
-    terminalreporter.write_sep("=", gettext("snapshot report summary"))
+    terminalreporter.write_sep("-", gettext("snapshot report summary"))
     for line in terminalreporter.config._syrupy.report.lines:
         terminalreporter.write_line(line)
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -1,4 +1,5 @@
 import glob
+from gettext import gettext
 from typing import (
     Any,
     List,
@@ -72,7 +73,7 @@ def pytest_sessionstart(session: Any) -> None:
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionstart
     """
     config = session.config
-    session._syrupy = SnapshotSession(
+    config._syrupy = SnapshotSession(
         warn_unused_snapshots=config.option.warn_unused_snapshots,
         update_snapshots=config.option.update_snapshots,
         base_dir=config.rootdir,
@@ -84,7 +85,7 @@ def pytest_sessionstart(session: Any) -> None:
             __is_testnode(arg) for arg in config.invocation_params.args
         ),
     )
-    session._syrupy.start()
+    config._syrupy.start()
 
 
 def pytest_collection_modifyitems(session: Any, config: Any, items: List[Any]) -> None:
@@ -92,7 +93,7 @@ def pytest_collection_modifyitems(session: Any, config: Any, items: List[Any]) -
     After tests are collected and before any modification is performed.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_collection_modifyitems
     """
-    session._syrupy._all_items.update(items)
+    config._syrupy._all_items.update(items)
 
 
 def pytest_collection_finish(session: Any) -> None:
@@ -100,19 +101,27 @@ def pytest_collection_finish(session: Any) -> None:
     After collection has been performed and modified.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_collection_finish
     """
-    session._syrupy._ran_items.update(session.items)
+    session.config._syrupy._ran_items.update(session.items)
 
 
 def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
     """
-    Add syrupy report to pytest after whole test run finished, before exiting.
+    Finish session run and set exit status.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionfinish
     """
-    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
-    syrupy_exitstatus = session._syrupy.finish()
-    for line in session._syrupy.report.lines:
-        reporter.write_line(line)
-    session.exitstatus |= syrupy_exitstatus
+    session.exitstatus |= exitstatus | session.config._syrupy.finish()
+
+
+def pytest_terminal_summary(
+    terminalreporter: Any, exitstatus: int, config: Any
+) -> None:
+    """
+    Add syrupy report to pytest.
+    https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_terminal_summary
+    """
+    terminalreporter.write_sep("=", gettext("snapshot report summary"))
+    for line in terminalreporter.config._syrupy.report.lines:
+        terminalreporter.write_line(line)
 
 
 @pytest.fixture
@@ -121,5 +130,5 @@ def snapshot(request: Any) -> "SnapshotAssertion":
         update_snapshots=request.config.option.update_snapshots,
         extension_class=DEFAULT_EXTENSION,
         test_location=TestLocation(request.node),
-        session=request.session._syrupy,
+        session=request.session.config._syrupy,
     )

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -132,7 +132,6 @@ class SnapshotReport:
 
     @property
     def lines(self) -> Generator[str, None, None]:
-        yield ""
         summary_lines: List[str] = []
         if self.num_failed:
             summary_lines.append(

--- a/tests/__snapshots__/test_integration_default.ambr
+++ b/tests/__snapshots__/test_integration_default.ambr
@@ -118,12 +118,6 @@
 # name: test_snapshot_default_extension_option
   '1 snapshot generated.'
 ---
-# name: test_snapshot_default_extension_option_failure
-  '
-  ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
-  pytest: error: argument --snapshot-default-extension: Member 'DoesNotExistExtension' not found in module 'syrupy.extensions.amber'.
-  '
----
 # name: test_unused_parameterized_ignored_if_not_targeted_using_dash_k
   '4 snapshots generated.'
 ---

--- a/tests/__snapshots__/test_integration_default.ambr
+++ b/tests/__snapshots__/test_integration_default.ambr
@@ -1,6 +1,8 @@
 # name: test_failing_snapshots_diff
   '
   
+  ________________________________ test_updated_1 ________________________________
+  
   snapshot = SnapshotAssertion(name='snapshot', num_executions=1)
   
       def test_updated_1(snapshot):
@@ -14,6 +16,7 @@
   E           ...
   
   test_file.py:17: AssertionError
+  ________________________________ test_updated_2 ________________________________
   
   snapshot = SnapshotAssertion(name='snapshot', num_executions=1)
   
@@ -27,6 +30,7 @@
   E           ...
   
   test_file.py:22: AssertionError
+  ________________________________ test_updated_3 ________________________________
   
   snapshot = SnapshotAssertion(name='snapshot', num_executions=1)
   
@@ -40,6 +44,7 @@
   E           ...
   
   test_file.py:27: AssertionError
+  ________________________________ test_updated_4 ________________________________
   
   snapshot = SnapshotAssertion(name='snapshot', num_executions=1)
   
@@ -50,6 +55,7 @@
   E         + 'sing line changeling'
   
   test_file.py:32: AssertionError
+  ________________________________ test_updated_5 ________________________________
   
   snapshot = SnapshotAssertion(name='snapshot', num_executions=1)
   
@@ -79,5 +85,106 @@
   E           ...
   
   test_file.py:37: AssertionError
+  --------------------------- snapshot report summary ----------------------------
   '
+---
+# name: test_generated_snapshots
+  '7 snapshots generated.'
+---
+# name: test_missing_snapshots
+  '1 snapshot failed.'
+---
+# name: test_removed_empty_snapshot_fossil_only
+  '
+  7 snapshots passed. 1 unused snapshot deleted.
+  
+  Deleted empty snapshot fossil (__snapshots__/test_empty.ambr)
+  '
+---
+# name: test_removed_snapshot_fossil
+  '
+  7 unused snapshots deleted.
+  
+  Deleted test_unused, test_updated_1, test_updated_2, test_updated_3, test_updated_4, test_updated_5, test_used (__snapshots__/test_file.ambr)
+  '
+---
+# name: test_removed_snapshots
+  '
+  6 snapshots passed. 1 unused snapshot deleted.
+  
+  Deleted test_unused (__snapshots__/test_file.ambr)
+  '
+---
+# name: test_snapshot_default_extension_option
+  '1 snapshot generated.'
+---
+# name: test_snapshot_default_extension_option_failure
+  '
+  ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
+  pytest: error: argument --snapshot-default-extension: Member 'DoesNotExistExtension' not found in module 'syrupy.extensions.amber'.
+  '
+---
+# name: test_unused_parameterized_ignored_if_not_targeted_using_dash_k
+  '4 snapshots generated.'
+---
+# name: test_unused_parameterized_ignored_if_not_targeted_using_dash_k.1
+  '
+  2 snapshots passed. 1 unused snapshot deleted.
+  
+  Deleted test_collected[3] (__snapshots__/test_collected.ambr)
+  '
+---
+# name: test_unused_snapshots
+  '
+  6 snapshots passed. 1 snapshot unused.
+  
+  Re-run pytest with --snapshot-update to delete unused snapshots.
+  '
+---
+# name: test_unused_snapshots_cleaned_up_when_targeting_specific_testfiles
+  '
+  7 unused snapshots deleted.
+  
+  Deleted test_unused, test_updated_1, test_updated_2, test_updated_3, test_updated_4, test_updated_5, test_used (__snapshots__/test_file.ambr)
+  '
+---
+# name: test_unused_snapshots_ignored_if_not_targeted_by_module_testfiles
+  '
+  6 snapshots passed. 1 unused snapshot deleted.
+  
+  Deleted test_unused (__snapshots__/test_file.ambr)
+  '
+---
+# name: test_unused_snapshots_ignored_if_not_targeted_by_testnode_ids
+  '1 snapshot passed.'
+---
+# name: test_unused_snapshots_ignored_if_not_targeted_using_dash_k
+  '4 snapshots generated.'
+---
+# name: test_unused_snapshots_ignored_if_not_targeted_using_dash_k.1
+  '
+  1 snapshot passed. 1 snapshot updated. 1 unused snapshot deleted.
+  
+  Deleted test_collected[3] (__snapshots__/test_collected.ambr)
+  '
+---
+# name: test_unused_snapshots_ignored_if_not_targeted_using_dash_m
+  '4 snapshots generated.'
+---
+# name: test_unused_snapshots_ignored_if_not_targeted_using_dash_m.1
+  '
+  1 snapshot passed. 1 snapshot updated. 1 unused snapshot deleted.
+  
+  Deleted test_collected[3] (__snapshots__/test_collected.ambr)
+  '
+---
+# name: test_unused_snapshots_warning
+  '
+  6 snapshots passed. 1 snapshot unused.
+  
+  Re-run pytest with --snapshot-update to delete unused snapshots.
+  '
+---
+# name: test_updated_snapshots
+  '2 snapshots passed. 5 snapshots updated.'
 ---

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -244,7 +244,7 @@ def test_failing_snapshots_diff(stubs, testcases_updated, snapshot):
     result = testdir.runpytest("-vv")
     result_stdout = clean_output(result.stdout.str())
     start_index = result_stdout.find("==== FAILURES")
-    end_index = result_stdout.find("==== 5 failed")
+    end_index = result_stdout.find("==== snapshot report summary")
     result_stdout = "\n".join(
         line
         for line in result_stdout[start_index:end_index].splitlines()
@@ -327,7 +327,7 @@ def test_unused_snapshots_ignored_if_not_targeted_by_module_testfiles(stubs):
 
 
 def test_unused_snapshots_cleaned_up_when_targeting_specific_testfiles(stubs):
-    _, testdir, tests, _ = stubs
+    _, testdir, _, _ = stubs
     testdir.makepyfile(
         test_file=(
             """

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -244,11 +244,12 @@ def test_failing_snapshots_diff(stubs, testcases_updated, snapshot):
     result = testdir.runpytest("-vv")
     result_stdout = clean_output(result.stdout.str())
     start_index = result_stdout.find("==== FAILURES")
-    end_index = result_stdout.find("==== snapshot report summary")
+    end_index = result_stdout.find("---- snapshot report summary")
+    filter_out = ["____", "----", "===="]
     result_stdout = "\n".join(
         line
         for line in result_stdout[start_index:end_index].splitlines()
-        if not line.startswith("____") and not line.startswith("====")
+        if not any(line.startswith(s) for s in filter_out)
     )
     assert snapshot == result_stdout
     assert result.ret == 1

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -398,5 +398,6 @@ def test_snapshot_default_extension_option_failure(testdir, testcases, snapshot)
         "syrupy.extensions.amber.DoesNotExistExtension",
     )
     result_stderr = clean_output(result.stderr.str())
-    assert result_stderr == snapshot
+    assert "error: argument --snapshot-default-extension" in result_stderr
+    assert "Member 'DoesNotExistExtension' not found" in result_stderr
     assert result.ret

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -7,9 +7,7 @@ from .utils import clean_output
 
 def get_result_snapshot_summary(result: object) -> str:
     result_stdout = clean_output(result.stdout.str())
-    start_idx = result_stdout.find(
-        "\n", result_stdout.find("---- snapshot report summary")
-    )
+    start_idx = result_stdout.find("\n", result_stdout.find("---- snapshot report"))
     end_idx = result_stdout.find("====", start_idx)
     return result_stdout[start_idx:end_idx].strip()
 

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -5,8 +5,17 @@ import pytest
 from .utils import clean_output
 
 
+def get_result_snapshot_summary(result: object) -> str:
+    result_stdout = clean_output(result.stdout.str())
+    start_idx = result_stdout.find(
+        "\n", result_stdout.find("---- snapshot report summary")
+    )
+    end_idx = result_stdout.find("====", start_idx)
+    return result_stdout[start_idx:end_idx].strip()
+
+
 @pytest.fixture
-def collection(testdir):
+def collection(testdir, snapshot):
     tests = {
         "test_collected": (
             """
@@ -26,13 +35,12 @@ def collection(testdir):
     }
     testdir.makepyfile(**tests)
     result = testdir.runpytest("-v", "--snapshot-update")
-    result_stdout = clean_output(result.stdout.str())
-    assert "4 snapshots generated" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": ""})
     return testdir
 
 
-def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
+def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection, snapshot):
     updated_tests = {
         "test_collected": (
             """
@@ -42,20 +50,17 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_m(collection):
             def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
-        ),
+        )
     }
     collection.makepyfile(**updated_tests)
     result = collection.runpytest("-v", "--snapshot-update", "-m", "parametrize")
-    result_stdout = clean_output(result.stdout.str())
-    assert "1 snapshot passed" in result_stdout
-    assert "1 snapshot updated" in result_stdout
-    assert "1 unused snapshot deleted" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     snapshot_path = [collection.tmpdir, "__snapshots__"]
     assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 
-def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection):
+def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection, snapshot):
     updated_tests = {
         "test_collected": (
             """
@@ -65,20 +70,19 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection):
             def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
-        ),
+        )
     }
     collection.makepyfile(**updated_tests)
     result = collection.runpytest("-v", "--snapshot-update", "-k", "test_collected[")
-    result_stdout = clean_output(result.stdout.str())
-    assert "1 snapshot passed" in result_stdout
-    assert "1 snapshot updated" in result_stdout
-    assert "1 unused snapshot deleted" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     snapshot_path = [collection.tmpdir, "__snapshots__"]
     assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 
-def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(collection):
+def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(
+    collection, snapshot
+):
     updated_tests = {
         "test_collected": (
             """
@@ -88,14 +92,11 @@ def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(collection):
             def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
-        ),
+        )
     }
     collection.makepyfile(**updated_tests)
     result = collection.runpytest("-v", "--snapshot-update", "-k", "test_collected[")
-    result_stdout = clean_output(result.stdout.str())
-    assert "2 snapshots passed" in result_stdout
-    assert "snapshot updated" not in result_stdout
-    assert "1 unused snapshot deleted" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     snapshot_path = [collection.tmpdir, "__snapshots__"]
     assert Path(*snapshot_path).joinpath("test_not_collected.ambr").exists()
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
@@ -209,10 +210,10 @@ def testcases_updated(testcases):
     return {**testcases, **updated_testcases}
 
 
-def test_missing_snapshots(testdir, testcases):
+def test_missing_snapshots(testdir, testcases, snapshot):
     testdir.makepyfile(test_file=testcases["used"])
     result = testdir.runpytest("-v")
-    assert "Snapshot does not exist" in clean_output(result.stdout.str())
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 1
 
 
@@ -230,11 +231,9 @@ def test_injected_fixture(stubs):
     assert result.ret == 0
 
 
-def test_generated_snapshots(stubs):
+def test_generated_snapshots(stubs, snapshot):
     result = stubs[0]
-    result_stdout = clean_output(result.stdout.str())
-    assert "7 snapshots generated" in result_stdout
-    assert "snapshots unused" not in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
 
 
@@ -243,51 +242,37 @@ def test_failing_snapshots_diff(stubs, testcases_updated, snapshot):
     testdir.makepyfile(test_file="\n\n".join(testcases_updated.values()))
     result = testdir.runpytest("-vv")
     result_stdout = clean_output(result.stdout.str())
-    start_index = result_stdout.find("==== FAILURES")
-    end_index = result_stdout.find("---- snapshot report summary")
-    filter_out = ["____", "----", "===="]
-    result_stdout = "\n".join(
-        line
-        for line in result_stdout[start_index:end_index].splitlines()
-        if not any(line.startswith(s) for s in filter_out)
-    )
-    assert snapshot == result_stdout
+    start_index = result_stdout.find("\n", result_stdout.find("==== FAILURES"))
+    end_index = result_stdout.find("\n", result_stdout.find("---- snapshot report"))
+    assert result_stdout[start_index:end_index] == snapshot
     assert result.ret == 1
 
 
-def test_updated_snapshots(stubs, testcases_updated):
+def test_updated_snapshots(stubs, testcases_updated, snapshot):
     testdir = stubs[1]
     testdir.makepyfile(test_file="\n\n".join(testcases_updated.values()))
     result = testdir.runpytest("-v", "--snapshot-update")
-    result_stdout = clean_output(result.stdout.str())
-    assert "2 snapshots passed" in result_stdout
-    assert "5 snapshots updated" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
 
 
-def test_unused_snapshots(stubs):
+def test_unused_snapshots(stubs, snapshot):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
     result = testdir.runpytest("-v")
-    result_stdout = clean_output(result.stdout.str())
-    assert "snapshots generated" not in result_stdout
-    assert "6 snapshots passed" in result_stdout
-    assert "1 snapshot unused" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 1
 
 
-def test_unused_snapshots_warning(stubs):
+def test_unused_snapshots_warning(stubs, snapshot):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
     result = testdir.runpytest("-v", "--snapshot-warn-unused")
-    result_stdout = clean_output(result.stdout.str())
-    assert "snapshots generated" not in result_stdout
-    assert "6 snapshots passed" in result_stdout
-    assert "1 snapshot unused" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
 
 
-def test_unused_snapshots_ignored_if_not_targeted_by_testnode_ids(testdir):
+def test_unused_snapshots_ignored_if_not_targeted_by_testnode_ids(testdir, snapshot):
     testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": ""})
     testdir.makefile(
         ".py",
@@ -306,28 +291,22 @@ def test_unused_snapshots_ignored_if_not_targeted_by_testnode_ids(testdir):
     result = testdir.runpytest(
         f"{testfile}::test_life_always_finds_a_way", "-v", "--snapshot-update"
     )
-    result_stdout = clean_output(result.stdout.str())
-    assert "1 snapshot passed" in result_stdout
-    assert "snapshots unused" not in result_stdout
-    assert "snapshot unused" not in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
     assert Path("__snapshots__/other_snapfile.ambr").exists()
 
 
-def test_unused_snapshots_ignored_if_not_targeted_by_module_testfiles(stubs):
+def test_unused_snapshots_ignored_if_not_targeted_by_module_testfiles(stubs, snapshot):
     _, testdir, tests, _ = stubs
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
-    testdir.makefile(
-        ".ambr", **{"__snapshots__/other_snapfile": ""},
-    )
+    testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": ""})
     result = testdir.runpytest("-v", "--snapshot-update", "test_file.py")
-    result_stdout = clean_output(result.stdout.str())
-    assert "1 unused snapshot deleted" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
     assert Path("__snapshots__/other_snapfile.ambr").exists()
 
 
-def test_unused_snapshots_cleaned_up_when_targeting_specific_testfiles(stubs):
+def test_unused_snapshots_cleaned_up_when_targeting_specific_testfiles(stubs, snapshot):
     _, testdir, _, _ = stubs
     testdir.makepyfile(
         test_file=(
@@ -337,57 +316,46 @@ def test_unused_snapshots_cleaned_up_when_targeting_specific_testfiles(stubs):
             """
         )
     )
-    testdir.makefile(
-        ".ambr", **{"__snapshots__/other_snapfile": ""},
-    )
+    testdir.makefile(".ambr", **{"__snapshots__/other_snapfile": ""})
     result = testdir.runpytest("-v", "--snapshot-update", "test_file.py")
-    result_stdout = clean_output(result.stdout.str())
-    assert "7 unused snapshots deleted" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
     assert Path("__snapshots__/other_snapfile.ambr").exists()
 
 
-def test_removed_snapshots(stubs):
+def test_removed_snapshots(stubs, snapshot):
     _, testdir, tests, filepath = stubs
     assert Path(filepath).exists()
     testdir.makepyfile(test_file="\n\n".join(tests[k] for k in tests if k != "unused"))
     result = testdir.runpytest("-v", "--snapshot-update")
-    result_stdout = clean_output(result.stdout.str())
-    assert "snapshot unused" not in result_stdout
-    assert "1 unused snapshot deleted" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
     assert Path(filepath).exists()
 
 
-def test_removed_snapshot_fossil(stubs):
+def test_removed_snapshot_fossil(stubs, snapshot):
     _, testdir, tests, filepath = stubs
     assert Path(filepath).exists()
     testdir.makepyfile(test_file=tests["inject"])
     result = testdir.runpytest("-v", "--snapshot-update")
-    result_stdout = clean_output(result.stdout.str())
-    assert "snapshots unused" not in result_stdout
-    assert "7 unused snapshots deleted" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
     assert not Path(filepath).exists()
 
 
-def test_removed_empty_snapshot_fossil_only(stubs):
+def test_removed_empty_snapshot_fossil_only(stubs, snapshot):
     _, testdir, _, filepath = stubs
     testdir.makefile(".ambr", **{"__snapshots__/test_empty": ""})
     empty_filepath = Path(testdir.tmpdir, "__snapshots__/test_empty.ambr")
     assert empty_filepath.exists()
     result = testdir.runpytest("-v", "--snapshot-update")
-    result_stdout = clean_output(result.stdout.str())
-    assert str(Path(filepath).relative_to(Path.cwd())) not in result_stdout
-    assert "1 unused snapshot deleted" in result_stdout
-    assert "empty snapshot" in result_stdout
-    assert str(empty_filepath.relative_to(Path.cwd())) in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert result.ret == 0
     assert Path(filepath).exists()
     assert not Path(empty_filepath).exists()
 
 
-def test_removed_hanging_snapshot_fossil(stubs):
+def test_removed_hanging_snapshot_fossil(stubs, snapshot):
     _, testdir, _, filepath = stubs
     testdir.makefile(".abc", **{"__snapshots__/test_hanging": ""})
     hanging_filepath = Path(testdir.tmpdir, "__snapshots__/test_hanging.abc")
@@ -403,7 +371,7 @@ def test_removed_hanging_snapshot_fossil(stubs):
     assert not Path(hanging_filepath).exists()
 
 
-def test_snapshot_default_extension_option(testdir):
+def test_snapshot_default_extension_option(testdir, snapshot):
     testdir.makepyfile(
         test_file=(
             """
@@ -418,13 +386,12 @@ def test_snapshot_default_extension_option(testdir):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result_stdout = clean_output(result.stdout.str())
-    assert "1 snapshot generated" in result_stdout
+    assert get_result_snapshot_summary(result) == snapshot
     assert Path(testdir.tmpdir, "__snapshots__/test_file/test_default.raw").exists()
     assert result.ret == 0
 
 
-def test_snapshot_default_extension_option_failure(testdir, testcases):
+def test_snapshot_default_extension_option_failure(testdir, testcases, snapshot):
     testdir.makepyfile(test_file=testcases["used"])
     result = testdir.runpytest(
         "-v",
@@ -433,6 +400,5 @@ def test_snapshot_default_extension_option_failure(testdir, testcases):
         "syrupy.extensions.amber.DoesNotExistExtension",
     )
     result_stderr = clean_output(result.stderr.str())
-    assert "error: argument --snapshot-default-extension" in result_stderr
-    assert "Member 'DoesNotExistExtension' not found" in result_stderr
+    assert result_stderr == snapshot
     assert result.ret

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -68,7 +68,7 @@ def test_unused_snapshots_ignored_if_not_targeted_using_dash_k(collection, snaps
             def test_collected(snapshot, actual):
                 assert snapshot == actual
             """
-        )
+        ),
     }
     collection.makepyfile(**updated_tests)
     result = collection.runpytest("-v", "--snapshot-update", "-k", "test_collected[")


### PR DESCRIPTION
## Description

Moves syrupy snapshot reporting to proper location

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #142 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I have updated the CHANGELOG.md.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
