### PR TITLE
fix: snapshot name warning showing on false negatives

### DIFF
--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -68,11 +68,7 @@ class SnapshotFossilizer(ABC):
     def get_snapshot_name(self, *, index: int = 0) -> str:
         """Get the snapshot name for the assertion index in a test location"""
         index_suffix = f".{index}" if index > 0 else ""
-        testname = self.test_location.testname
-
-        if self.test_location.classname is not None:
-            return f"{self.test_location.classname}.{testname}{index_suffix}"
-        return f"{testname}{index_suffix}"
+        return f"{self.test_location.snapshot_name}{index_suffix}"
 
     def get_location(self, *, index: int) -> str:
         """Returns full location where snapshot data is stored."""
@@ -251,7 +247,7 @@ class SnapshotReporter(ABC):
         return SYMBOL_CARRIAGE
 
     def __diff_lines(self, a: str, b: str) -> Iterator[str]:
-        for line in self.__diff_data(a, b):
+        for line in self.__diffed_lines(a, b):
             show_ends = (
                 self.__strip_ends(line.a[1:]) == self.__strip_ends(line.b[1:])
                 if line.is_complete
@@ -267,7 +263,7 @@ class SnapshotReporter(ABC):
                 )
             yield from map(context_style, self.__limit_context(line.c))
 
-    def __diff_data(self, a: str, b: str) -> Iterator["DiffedLine"]:
+    def __diffed_lines(self, a: str, b: str) -> Iterator["DiffedLine"]:
         staged_diffed_line: Optional["DiffedLine"] = None
         for line in ndiff(a.splitlines(keepends=True), b.splitlines(keepends=True)):
             is_context_line = line[0] == " "

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -23,6 +23,12 @@ class TestLocation:
     def filename(self) -> str:
         return Path(self.filepath).stem
 
+    @property
+    def snapshot_name(self) -> str:
+        if self.classname is not None:
+            return f"{self.classname}.{self.testname}"
+        return str(self.testname)
+
     def __valid_id(self, name: str) -> str:
         [valid_id, *rest] = name
         while rest:
@@ -33,7 +39,7 @@ class TestLocation:
         return valid_id
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
-        return self.__valid_id(str(self.methodname)) == self.__valid_id(snapshot_name)
+        return self.__valid_id(self.snapshot_name) == self.__valid_id(snapshot_name)
 
     def matches_snapshot_location(self, snapshot_location: str) -> bool:
         return self.filename in snapshot_location


### PR DESCRIPTION
## Description

Fixes snapshot name warning showing up incorrectly on snapshot creation.

## DevQA

**STR**
- `git checkout master`
- `rm */**.ambr`
- `pytest --snapshot-update`
- See warnings

**FIX**
- `git checkout fix-warning`
- `rm */**.ambr`
- `pytest --snapshot-update`
- No warnings

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

No additional comments.
