### PR TITLE
fix: specify correct min version of pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "attrs>=18.2.0,<20.0.0",
     "colored>=1.3.92,<2.0.0",
     "typing_extensions>=3.6,<4.0.0",
-    "pytest>=5.0.0,<6.0.0",
+    "pytest>=5.1.0,<6.0.0",
 ]
 test_requires = [
     "codecov",


### PR DESCRIPTION
## Description

Specifies correct min version of pytest

### QA
- `pip install -U pytest==5.0.0`
- `pytest`
- **See failure**
- `pip install -U pytest==5.1.0`
- `pytest`
- **See success**

## Related Issues

- Closes #156 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
