### PR TITLE
Fix warnings

### DIFF
--- a/tests/test_extension_image.py
+++ b/tests/test_extension_image.py
@@ -51,5 +51,6 @@ def test_multiple_snapshot_extensions(snapshot):
     """
     assert actual_svg == snapshot(extension_class=SVGImageSnapshotExtension)
     assert actual_svg == snapshot  # uses initial extension class
+    assert snapshot._extension is not None
     assert actual_png == snapshot(extension_class=PNGImageSnapshotExtension)
     assert actual_svg == snapshot(extension_class=SVGImageSnapshotExtension)


### PR DESCRIPTION
## Description

- Fixes an issue where the assertion `_extension` property cache is always cleared
- Fixes warnings below
> PytestDeprecationWarning: TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.
  See https://docs.pytest.org/en/latest/deprecations.html#terminalreporter-writer for more information.

## Related Issues

N/A

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
