### PR TITLE
fix: correctly track unused snapshots in classes

### DIFF
--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -38,8 +38,11 @@ class TestLocation:
             valid_id = new_valid_id
         return valid_id
 
+    def __parse(self, name: str) -> str:
+        return ".".join(self.__valid_id(n) for n in name.split("."))
+
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
-        return self.__valid_id(self.snapshot_name) == self.__valid_id(snapshot_name)
+        return self.__parse(self.snapshot_name) == self.__parse(snapshot_name)
 
     def matches_snapshot_location(self, snapshot_location: str) -> bool:
         return self.filename in snapshot_location

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -100,6 +100,55 @@ def test_unused_parameterized_ignored_if_not_targeted_using_dash_k(
     assert Path(*snapshot_path).joinpath("other_snapfile.ambr").exists()
 
 
+def test_only_updates_targeted_snapshot_in_class_for_single_file(testdir):
+    test_content = """
+        import pytest
+
+        class TestClass:
+            def test_case_1(self, snapshot):
+                assert snapshot == 1
+
+            def test_case_2(self, snapshot):
+                assert snapshot == 2
+        """
+
+    testdir.makepyfile(test_content=test_content)
+    result = testdir.runpytest("-v", "--snapshot-update")
+
+    snapshot_path = Path(testdir.tmpdir, "__snapshots__")
+    assert snapshot_path.joinpath("test_content.ambr").exists()
+
+    test_filepath = Path(testdir.tmpdir, "test_content.py")
+    result = testdir.runpytest(str(test_filepath), "-v", "-k test_case_2")
+    result_stdout = clean_output(result.stdout.str())
+    assert "1 snapshot passed" in result_stdout
+    assert "snapshot unused" not in result_stdout
+
+
+def test_only_updates_targeted_snapshot_for_single_file(testdir):
+    test_content = """
+        import pytest
+
+        def test_case_1(snapshot):
+            assert snapshot == 1
+
+        def test_case_2(snapshot):
+            assert snapshot == 2
+        """
+
+    testdir.makepyfile(test_content=test_content)
+    result = testdir.runpytest("-v", "--snapshot-update")
+
+    snapshot_path = Path(testdir.tmpdir, "__snapshots__")
+    assert snapshot_path.joinpath("test_content.ambr").exists()
+
+    test_filepath = Path(testdir.tmpdir, "test_content.py")
+    result = testdir.runpytest(str(test_filepath), "-v", "-k test_case_2")
+    result_stdout = clean_output(result.stdout.str())
+    assert "1 snapshot passed" in result_stdout
+    assert "snapshot unused" not in result_stdout
+
+
 @pytest.fixture
 def testcases():
     return {


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Fixes a bug where targeting a specific subset of tests in a test class would incorrectly report the non-targeted test cases as "unused".

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.
