### PR TITLE
fix: remove added trailing whitespace from multiline string

### DIFF
--- a/src/syrupy/extensions/amber.py
+++ b/src/syrupy/extensions/amber.py
@@ -104,7 +104,8 @@ class DataSerializer:
             return (
                 cls.with_indent("'\n", depth)
                 + str(data)
-                + cls.with_indent("\n'", depth)
+                + "\n"
+                + cls.with_indent("'", depth)
             )
         return cls.with_indent(repr(data), depth)
 

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -139,6 +139,14 @@
     },
   ]
 ---
+# name: test_list_in_dict
+  <class 'dict'> {
+    'value': '
+  line 1
+  line 2
+    ',
+  }
+---
 # name: test_multiple_snapshots
   'First.'
 ---

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -23,6 +23,11 @@ def test_newline_control_characters(snapshot):
     assert snapshot == "line 1\r\nline 2\r\n"
 
 
+def test_list_in_dict(snapshot):
+    lines = "\n".join(["line 1", "line 2"])
+    assert {"value": lines} == snapshot
+
+
 @pytest.mark.parametrize("actual", [False, True])
 def test_bool(actual, snapshot):
     assert actual == snapshot


### PR DESCRIPTION
## Description

Serialization improvements. DON'T MERGE

## Related Issues

- Closes #183, removes added trailing whitespace from multiline string

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [ ] I will merge this pull request with a semantic title.

