### PR TITLE
fix: parsing identifiers from snapshot names (#186)

### DIFF
--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -30,16 +30,17 @@ class TestLocation:
         return str(self.testname)
 
     def __valid_id(self, name: str) -> str:
-        [valid_id, *rest] = name
-        while rest:
-            new_valid_id = f"{valid_id}{rest.pop(0)}"
+        valid_id = ""
+        for char in name:
+            new_valid_id = f"{valid_id}{char}"
             if not new_valid_id.isidentifier():
                 break
             valid_id = new_valid_id
         return valid_id
 
     def __parse(self, name: str) -> str:
-        return ".".join(self.__valid_id(n) for n in name.split("."))
+        valid_ids = (self.__valid_id(n) for n in name.split("."))
+        return ".".join(valid_id for valid_id in valid_ids if valid_id)
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
         return self.__parse(self.snapshot_name) == self.__parse(snapshot_name)

--- a/tests/test_integration_default.py
+++ b/tests/test_integration_default.py
@@ -113,7 +113,7 @@ def test_only_updates_targeted_snapshot_in_class_for_single_file(testdir):
         """
 
     testdir.makepyfile(test_content=test_content)
-    result = testdir.runpytest("-v", "--snapshot-update")
+    testdir.runpytest("-v", "--snapshot-update")
 
     snapshot_path = Path(testdir.tmpdir, "__snapshots__")
     assert snapshot_path.joinpath("test_content.ambr").exists()
@@ -137,7 +137,7 @@ def test_only_updates_targeted_snapshot_for_single_file(testdir):
         """
 
     testdir.makepyfile(test_content=test_content)
-    result = testdir.runpytest("-v", "--snapshot-update")
+    testdir.runpytest("-v", "--snapshot-update")
 
     snapshot_path = Path(testdir.tmpdir, "__snapshots__")
     assert snapshot_path.joinpath("test_content.ambr").exists()
@@ -147,6 +147,22 @@ def test_only_updates_targeted_snapshot_for_single_file(testdir):
     result_stdout = clean_output(result.stdout.str())
     assert "1 snapshot passed" in result_stdout
     assert "snapshot unused" not in result_stdout
+
+
+def test_multiple_snapshots(testdir):
+    test_content = """
+        import pytest
+
+        def test_case_1(snapshot):
+            assert snapshot == 1
+            assert snapshot == 2
+        """
+
+    testdir.makepyfile(test_content=test_content)
+    result = testdir.runpytest("-v", "--snapshot-update")
+
+    result_stdout = clean_output(result.stdout.str())
+    assert "Can not relate snapshot name" not in result_stdout
 
 
 @pytest.fixture


### PR DESCRIPTION
See: https://github.com/tophat/syrupy/pull/186

Author: https://github.com/taion