### PR TITLE
fix: show snapshot data in report when does not exist

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -72,7 +72,7 @@ class SnapshotAssertion:
         return self._execution_results
 
     def use_extension(
-        self, extension_class: Optional[Type["AbstractSyrupyExtension"]] = None,
+        self, extension_class: Optional[Type["AbstractSyrupyExtension"]] = None
     ) -> "SnapshotAssertion":
         """
         Creates a new snapshot assertion fixture with the same options but using
@@ -92,12 +92,11 @@ class SnapshotAssertion:
         assertion_result = self._execution_results[self.num_executions - 1]
         snapshot_data = assertion_result.recalled_data
         serialized_data = self.extension.serialize(data)
-        if snapshot_data is None:
-            return [gettext("Snapshot does not exist!")]
-
         diff: List[str] = []
+        if snapshot_data is None:
+            diff.append(gettext("Snapshot does not exist!"))
         if not assertion_result.success:
-            diff.extend(self.extension.diff_lines(serialized_data, snapshot_data))
+            diff.extend(self.extension.diff_lines(serialized_data, snapshot_data or ""))
         return diff
 
     def __call__(

--- a/tests/test_integration_single_file.py
+++ b/tests/test_integration_single_file.py
@@ -64,10 +64,12 @@ def testcases_updated(testcases):
     return {**testcases, **updated_testcases}
 
 
-def test_unsaved_snapshots(testdir, testcases):
+def test_unsaved_snapshots(snapshot, testdir, testcases):
     testdir.makepyfile(test_file=testcases["passed"])
     result = testdir.runpytest("-v")
-    assert "Snapshot does not exist" in clean_output(result.stdout.str())
+    output = clean_output(result.stdout.str())
+    assert "Snapshot does not exist" in output
+    assert "+ b'passed1'" in output
     assert result.ret == 1
 
 


### PR DESCRIPTION
## Description

Prints out the snapshot that will be created when it does not exist

### Before

<img width="424" alt="Screen Shot 2020-04-17 at 2 15 20 AM" src="https://user-images.githubusercontent.com/2528959/79537985-6e551f00-8051-11ea-9809-a63165494824.png">

### After

<img width="424" alt="Screen Shot 2020-04-17 at 2 15 56 AM" src="https://user-images.githubusercontent.com/2528959/79537995-744b0000-8051-11ea-8b56-e4458cc54c5e.png">

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #184 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
