### PR TITLE
feat: v0.4.0 - Amber serializer changes

### DIFF
--- a/src/syrupy/extensions/amber.py
+++ b/src/syrupy/extensions/amber.py
@@ -103,7 +103,10 @@ class DataSerializer:
         if "\n" in data:
             return (
                 cls.with_indent("'\n", depth)
-                + str(data)
+                + "".join(
+                    cls.with_indent(line, depth + 1 if depth else depth)
+                    for line in str(data).splitlines(keepends=True)
+                )
                 + "\n"
                 + cls.with_indent("'", depth)
             )

--- a/src/syrupy/extensions/amber.py
+++ b/src/syrupy/extensions/amber.py
@@ -104,7 +104,8 @@ class DataSerializer:
             return (
                 cls.with_indent("'\n", depth)
                 + str(data)
-                + cls.with_indent("\n'", depth)
+                + "\n"
+                + cls.with_indent("'", depth)
             )
         return cls.with_indent(repr(data), depth)
 

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -97,6 +97,17 @@
     'd': ...,
   }
 ---
+# name: test_deeply_nested_multiline_string_in_dict
+  <class 'dict'> {
+    'value_a': <class 'dict'> {
+      'value_b': '
+        line 1
+        line 2
+        line 3
+      ',
+    },
+  }
+---
 # name: test_dict[actual0]
   <class 'dict'> {
     'a': <class 'dict'> {
@@ -160,11 +171,11 @@
     },
   ]
 ---
-# name: test_list_in_dict
+# name: test_multiline_string_in_dict
   <class 'dict'> {
     'value': '
-  line 1
-  line 2
+      line 1
+      line 2
     ',
   }
 ---

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -160,6 +160,14 @@
     },
   ]
 ---
+# name: test_list_in_dict
+  <class 'dict'> {
+    'value': '
+  line 1
+  line 2
+    ',
+  }
+---
 # name: test_multiple_snapshots
   'First.'
 ---

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -23,6 +23,11 @@ def test_newline_control_characters(snapshot):
     assert snapshot == "line 1\r\nline 2\r\n"
 
 
+def test_list_in_dict(snapshot):
+    lines = "\n".join(["line 1", "line 2"])
+    assert {"value": lines} == snapshot
+
+
 @pytest.mark.parametrize("actual", [False, True])
 def test_bool(actual, snapshot):
     assert actual == snapshot

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -23,9 +23,15 @@ def test_newline_control_characters(snapshot):
     assert snapshot == "line 1\r\nline 2\r\n"
 
 
-def test_list_in_dict(snapshot):
+def test_multiline_string_in_dict(snapshot):
     lines = "\n".join(["line 1", "line 2"])
     assert {"value": lines} == snapshot
+
+
+def test_deeply_nested_multiline_string_in_dict(snapshot):
+    lines = "\n".join(["line 1", "line 2", "line 3"])
+    d = {"value_a": {"value_b": lines}}
+    assert d == snapshot
 
 
 @pytest.mark.parametrize("actual", [False, True])


### PR DESCRIPTION
## Description

v0.4.0 contains some breaking changes to the amber snapshot serializer.

## Related Issues

- Closes #183, removes added trailing whitespace from multiline string
- Closes #193, multiline strings should be indented according to parent

## Checklist

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.
