### PR TITLE
feat(amber): indent multiline strings, close #193

### DIFF
--- a/src/syrupy/extensions/amber.py
+++ b/src/syrupy/extensions/amber.py
@@ -103,7 +103,10 @@ class DataSerializer:
         if "\n" in data:
             return (
                 cls.with_indent("'\n", depth)
-                + str(data)
+                + "".join(
+                    cls.with_indent(line, depth + 1 if depth else depth)
+                    for line in str(data).splitlines(keepends=True)
+                )
                 + "\n"
                 + cls.with_indent("'", depth)
             )

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -76,7 +76,7 @@
     'd': ...,
   }
 ---
-# name: test_deeply_nested_list_in_dict
+# name: test_deeply_nested_multiline_string_in_dict
   <class 'dict'> {
     'value_a': <class 'dict'> {
       'value_b': '
@@ -150,7 +150,7 @@
     },
   ]
 ---
-# name: test_list_in_dict
+# name: test_multiline_string_in_dict
   <class 'dict'> {
     'value': '
       line 1

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -76,6 +76,17 @@
     'd': ...,
   }
 ---
+# name: test_deeply_nested_list_in_dict
+  <class 'dict'> {
+    'value_a': <class 'dict'> {
+      'value_b': '
+        line 1
+        line 2
+        line 3
+      ',
+    },
+  }
+---
 # name: test_dict[actual0]
   <class 'dict'> {
     'a': <class 'dict'> {
@@ -142,8 +153,8 @@
 # name: test_list_in_dict
   <class 'dict'> {
     'value': '
-  line 1
-  line 2
+      line 1
+      line 2
     ',
   }
 ---

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -28,6 +28,12 @@ def test_list_in_dict(snapshot):
     assert {"value": lines} == snapshot
 
 
+def test_deeply_nested_list_in_dict(snapshot):
+    lines = "\n".join(["line 1", "line 2", "line 3"])
+    d = {"value_a": {"value_b": lines}}
+    assert d == snapshot
+
+
 @pytest.mark.parametrize("actual", [False, True])
 def test_bool(actual, snapshot):
     assert actual == snapshot

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -23,12 +23,12 @@ def test_newline_control_characters(snapshot):
     assert snapshot == "line 1\r\nline 2\r\n"
 
 
-def test_list_in_dict(snapshot):
+def test_multiline_string_in_dict(snapshot):
     lines = "\n".join(["line 1", "line 2"])
     assert {"value": lines} == snapshot
 
 
-def test_deeply_nested_list_in_dict(snapshot):
+def test_deeply_nested_multiline_string_in_dict(snapshot):
     lines = "\n".join(["line 1", "line 2", "line 3"])
     d = {"value_a": {"value_b": lines}}
     assert d == snapshot


### PR DESCRIPTION
## Description

Indents multiline strings only when the parent itself is indented, this is to keep snapshots of multiline strings that are not nested in any data structure, simple.

## Related Issues

- Closes #193, multiline strings should be indented according to parent

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

