### PR TITLE
fix: use the test node location when determining snapshot class name

### DIFF
--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import (
     Any,
+    Iterator,
     Optional,
 )
 
@@ -16,8 +17,8 @@ class TestLocation:
 
     @property
     def classname(self) -> Optional[str]:
-        classes = self._node.obj.__qualname__.split(".")[:-1]
-        return ".".join(classes) if classes else None
+        _, __, qualname = self._node.location
+        return ".".join(list(self.__valid_ids(qualname))[:-1]) or None
 
     @property
     def filename(self) -> str:
@@ -38,9 +39,11 @@ class TestLocation:
             valid_id = new_valid_id
         return valid_id
 
+    def __valid_ids(self, name: str) -> Iterator[str]:
+        return filter(None, (self.__valid_id(n) for n in name.split(".")))
+
     def __parse(self, name: str) -> str:
-        valid_ids = (self.__valid_id(n) for n in name.split("."))
-        return ".".join(valid_id for valid_id in valid_ids if valid_id)
+        return ".".join(self.__valid_ids(name))
 
     def matches_snapshot_name(self, snapshot_name: str) -> bool:
         return self.__parse(self.snapshot_name) == self.__parse(snapshot_name)

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -19,6 +19,27 @@
 # name: TestClass.test_class_method_parametrized[c]
   'c'
 ---
+# name: TestSubClass.TestNestedClass.test_nested_class_method[x]
+  'parameterized nested class method x'
+---
+# name: TestSubClass.TestNestedClass.test_nested_class_method[y]
+  'parameterized nested class method y'
+---
+# name: TestSubClass.TestNestedClass.test_nested_class_method[z]
+  'parameterized nested class method z'
+---
+# name: TestSubClass.test_class_method_name
+  'this is in a test class'
+---
+# name: TestSubClass.test_class_method_parametrized[a]
+  'a'
+---
+# name: TestSubClass.test_class_method_parametrized[b]
+  'b'
+---
+# name: TestSubClass.test_class_method_parametrized[c]
+  'c'
+---
 # name: test_bool[False]
   False
 ---

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -154,3 +154,7 @@ class TestClass:
     class TestNestedClass:
         def test_nested_class_method(self, snapshot, actual):
             assert snapshot == f"parameterized nested class method {actual}"
+
+
+class TestSubClass(TestClass):
+    pass


### PR DESCRIPTION
## Description

Use the pytest node location to parse the full class name path

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #195

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
