### PR TITLE
fix: specify encoding when reading and writing amber fossils

### DIFF
--- a/src/syrupy/extensions/amber.py
+++ b/src/syrupy/extensions/amber.py
@@ -37,7 +37,7 @@ class DataSerializer:
         Writes the snapshot data into the snapshot file that be read later.
         """
         filepath = snapshot_fossil.location
-        with open(filepath, "w", newline="") as f:
+        with open(filepath, "w", encoding="utf-8", newline="") as f:
             for snapshot in sorted(snapshot_fossil, key=lambda s: s.name):
                 snapshot_data = str(snapshot.data)
                 if snapshot_data is not None:
@@ -57,7 +57,7 @@ class DataSerializer:
         indent_len = len(cls._indent)
         snapshot_fossil = SnapshotFossil(location=filepath)
         try:
-            with open(filepath, "r", newline="") as f:
+            with open(filepath, "r", encoding="utf-8", newline="") as f:
                 test_name = None
                 snapshot_data = ""
                 for line in f:


### PR DESCRIPTION
## Description

Specifies what encoding to use when reading and writing snapshots to amber fossils

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #196

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

- Unable to test atm
