### PR TITLE
fix: Handle dotted parameters in classname

### DIFF
--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -5,6 +5,8 @@ from typing import (
     Optional,
 )
 
+from pytest import Class
+
 
 class TestLocation:
     def __init__(self, node: Any):
@@ -17,8 +19,12 @@ class TestLocation:
 
     @property
     def classname(self) -> Optional[str]:
-        _, __, qualname = self._node.location
-        return ".".join(list(self.__valid_ids(qualname))[:-1]) or None
+        return (
+            ".".join(
+                node.name for node in self._node.listchain() if isinstance(node, Class)
+            )
+            or None
+        )
 
     @property
     def filename(self) -> str:

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -5,8 +5,6 @@ from typing import (
     Optional,
 )
 
-from pytest import Class
-
 
 class TestLocation:
     def __init__(self, node: Any):
@@ -19,12 +17,8 @@ class TestLocation:
 
     @property
     def classname(self) -> Optional[str]:
-        return (
-            ".".join(
-                node.name for node in self._node.listchain() if isinstance(node, Class)
-            )
-            or None
-        )
+        _, __, qualname = self._node.location
+        return ".".join(list(self.__valid_ids(qualname))[:-1]) or None
 
     @property
     def filename(self) -> str:
@@ -46,7 +40,12 @@ class TestLocation:
         return valid_id
 
     def __valid_ids(self, name: str) -> Iterator[str]:
-        return filter(None, (self.__valid_id(n) for n in name.split(".")))
+        for n in name.split("."):
+            valid_id = self.__valid_id(n)
+            if valid_id:
+                yield valid_id
+            if valid_id != n:
+                break
 
     def __parse(self, name: str) -> str:
         return ".".join(self.__valid_ids(name))

--- a/stubs/pytest.pyi
+++ b/stubs/pytest.pyi
@@ -3,6 +3,3 @@ from typing import Any, Callable, TypeVar
 ReturnType = TypeVar("ReturnType")
 
 def fixture(func: Callable[..., ReturnType]) -> Callable[..., ReturnType]: ...
-
-class Class:
-    name: str

--- a/stubs/pytest.pyi
+++ b/stubs/pytest.pyi
@@ -3,3 +3,6 @@ from typing import Any, Callable, TypeVar
 ReturnType = TypeVar("ReturnType")
 
 def fixture(func: Callable[..., ReturnType]) -> Callable[..., ReturnType]: ...
+
+class Class:
+    name: str

--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -155,6 +155,12 @@
     ],
   }
 ---
+# name: test_doubly_parametrized[bar-foo]
+  'foo'
+---
+# name: test_doubly_parametrized[bar-foo].1
+  'bar'
+---
 # name: test_empty_snapshot
   None
 ---
@@ -215,6 +221,9 @@
 ---
 # name: test_numbers.2
   0.3333333333333333
+---
+# name: test_parameter_with_dot[value.with.dot]
+  'value.with.dot'
 ---
 # name: test_reflection
   SnapshotAssertion(name='snapshot', num_executions=0)

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -169,3 +169,15 @@ class TestClass:
 
 class TestSubClass(TestClass):
     pass
+
+
+@pytest.mark.parametrize("parameter_with_dot", ("value.with.dot",))
+def test_parameter_with_dot(parameter_with_dot, snapshot):
+    assert parameter_with_dot == snapshot
+
+
+@pytest.mark.parametrize("parameter_1", ("foo",))
+@pytest.mark.parametrize("parameter_2", ("bar",))
+def test_doubly_parametrized(parameter_1, parameter_2, snapshot):
+    assert parameter_1 == snapshot
+    assert parameter_2 == snapshot


### PR DESCRIPTION
Continuation of #200 

## Description

This fixes a regression from https://github.com/tophat/syrupy/pull/197 for tests with parameters with dots in them.

## Related Issues

https://github.com/tophat/syrupy/pull/197, sorta

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

Without this change, the dotted parameter name would confuse the earlier iteration of the `classname` logic.