### PR TITLE
chore: remove unnecessary shebang from script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Based on conventions from https://github.com/github/scripts-to-rule-them-all
 # script/bootstrap: Resolve all dependencies that the application requires to
 # run.


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Since the bootstrap script is meant to be sourced (`. script/bootstrap`) rather than executed (`./script/bootstrap`), the shebang is a bit misleading.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

N/A

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient test coverage.
- [ ] I will merge this pull request with a semantic title.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

Just noticed this because I adopted the `scripts/` pattern in a recent project and used your scripts as a starting point.

Thanks for the great project, btw.
