### PR TITLE
Update setup.py, so that it allows for any Python 3.6+ version to be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 )
 
 
-python_requires = "~=3.6"
+python_requires = ">=3.6"
 setup_requires = ["setuptools_scm"]
 install_requires = [
     "attrs>=18.2.0,<20.0.0",
@@ -39,8 +39,8 @@ dev_requires = [
     *test_requires,
 ]
 
-if sys.version_info[0] == 2:
-    raise Exception("Only python 3 supported.")
+if sys.version_info < (3, 6):
+    raise RuntimeError("Only Python 3.6+ supported.")
 
 
 def readme() -> str:


### PR DESCRIPTION
## Description

The project supports any Python 3.6+ version, so we need to reflect this in `setup.py`.

## Related Issues

- Closes #238: Python version in setup.py is outdated

## Checklist

- [x] This PR has sufficient test coverage.
- [x] I will merge this pull request with a semantic title.

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
