### PR TITLE
fix: sort iterables when serializing

### DIFF
--- a/tests/__snapshots__/test_extension_amber.ambr
+++ b/tests/__snapshots__/test_extension_amber.ambr
@@ -167,6 +167,20 @@
 # name: test_empty_snapshot.1
   ''
 ---
+# name: test_iterable
+  <class 'generator'> (
+    7,
+    3,
+    5,
+    6,
+    0,
+    8,
+    9,
+    4,
+    2,
+    1,
+  )
+---
 # name: test_list
   <class 'list'> [
     1,

--- a/tests/test_extension_amber.py
+++ b/tests/test_extension_amber.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import random
 
 import pytest
 
@@ -108,6 +109,13 @@ def test_numbers(snapshot):
     assert snapshot == 3.5
     assert snapshot == 7
     assert snapshot == 2 / 6
+
+
+def test_iterable(snapshot):
+    def generator():
+        yield from random.sample(range(10), 10)
+
+    assert generator() == snapshot
 
 
 def test_list(snapshot):


### PR DESCRIPTION
## Description

Sorts iterables when serializing

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
