### PR TITLE
chore: Mark compatibility with pytest v6.x

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,30 +8,31 @@ appdirs==1.4.4            # via black
 attrs==19.3.0             # via black, flake8-bugbear, pytest, syrupy
 black==19.10b0            # via syrupy
 bleach==3.1.5             # via readme-renderer
-certifi==2020.6.20       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via black, pip-tools
-codecov==2.1.8           # via syrupy
+codecov==2.1.8            # via syrupy
+colorama==0.4.3           # via twine
 colored==1.4.2            # via syrupy
 configparser==5.0.0       # via py-githooks
 coverage[toml]==5.2.1     # via codecov, syrupy
-deprecated==1.2.10         # via pygithub
+deprecated==1.2.10        # via pygithub
 docutils==0.16            # via readme-renderer
-entrypoints==0.3          # via flake8
 flake8-bugbear==20.1.4    # via syrupy
 flake8-builtins==1.5.3    # via syrupy
 flake8-comprehensions==3.2.3  # via syrupy
 flake8-i18n==0.1.0        # via syrupy
 flake8==3.8.3             # via flake8-bugbear, flake8-builtins, flake8-comprehensions, flake8-i18n, syrupy
-idna==2.10                 # via requests
+idna==2.10                # via requests
+iniconfig==1.0.0          # via pytest
 invoke==1.4.1             # via syrupy
-isort==5.2.0             # via syrupy
+isort==5.2.0              # via syrupy
 keyring==21.2.1           # via twine
 mccabe==0.6.1             # via flake8
 more-itertools==8.4.0     # via pytest
 mypy-extensions==0.4.3    # via mypy
 mypy==0.782               # via syrupy
-packaging==20.4           # via pytest
+packaging==20.4           # via bleach, pytest
 pathspec==0.8.0           # via black
 pip-tools==5.3.0          # via syrupy
 pkginfo==1.5.0.1          # via twine
@@ -45,23 +46,24 @@ pygments==2.6.1           # via readme-renderer
 pyjwt==1.7.1              # via pygithub
 pyparsing==2.4.7          # via packaging
 pyperf==2.0.0             # via syrupy
-pytest==5.4.3             # via syrupy
+pytest==6.0.0             # via syrupy
 readme-renderer==26.0     # via twine
-regex==2020.7.14           # via black
+regex==2020.7.14          # via black
 requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via codecov, pygithub, requests-toolbelt, twine
-semver==2.10.2             # via syrupy
+rfc3986==1.4.0            # via twine
+semver==2.10.2            # via syrupy
 six==1.15.0               # via bleach, packaging, pip-tools, readme-renderer
-toml==0.10.1              # via black, coverage
+toml==0.10.1              # via black, coverage, pytest
 tqdm==4.48.0              # via twine
 twine==3.2.0              # via syrupy
 typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.2  # via mypy, syrupy
-urllib3==1.25.10           # via requests
-wcwidth==0.2.5            # via pytest
+urllib3==1.25.10          # via requests
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via syrupy
 wrapt==1.12.1             # via deprecated
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==20.1.1               # via pip-tools
 setuptools==49.2.0        # via twine

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     "attrs>=18.2.0,<20.0.0",
     "colored>=1.3.92,<2.0.0",
     "typing_extensions>=3.6,<4.0.0",
-    "pytest>=5.1.0,<6.0.0",
+    "pytest>=5.1.0,<7.0.0",
 ]
 test_requires = [
     "codecov",


### PR DESCRIPTION
## Description

This widens the dependency range for pytest in `setup.py`, which allows me to upgrade to pytest v6.x without pip-tools complaining at me.

## Checklist

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

None of the breaking changes are relevant, as far as I can tell. I can run pytest v6 together with Syrupy without obvious problems.