### PR TITLE
fix: only perform session finish on test items actually ran

### DIFF
--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -358,6 +358,7 @@ class SnapshotReport:
         return any(
             PyTestLocation(item).matches_snapshot_name(snapshot_name)
             for item in self.ran_items
+            if self.ran_items[item]
         )
 
     def _selected_items_match_name(self, snapshot_name: str) -> bool:
@@ -378,6 +379,7 @@ class SnapshotReport:
         return any(
             PyTestLocation(item).matches_snapshot_location(snapshot_location)
             for item in self.ran_items
+            if self.ran_items[item]
         )
 
 

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -27,7 +27,9 @@ class SnapshotSession:
     warn_unused_snapshots: bool = attr.ib()
     _invocation_args: Tuple[str, ...] = attr.ib(factory=tuple)
     report: Optional["SnapshotReport"] = attr.ib(default=None)
+    # All the collected test items
     _all_items: Dict["pytest.Item", bool] = attr.ib(factory=dict)
+    # All the selected test items. Will be set to False until the test item is run.
     _ran_items: Dict["pytest.Item", bool] = attr.ib(factory=dict)
     _assertions: List["SnapshotAssertion"] = attr.ib(factory=list)
     _extensions: Dict[str, "AbstractSyrupyExtension"] = attr.ib(factory=dict)


### PR DESCRIPTION
## Description

Interrupting a test run leads to syrupy assuming all selected but untouched snapshots are unused and should be marked as candidates for deletion.

**Before**

<img width="1077" alt="Screen Shot 2020-10-29 at 11 53 52 PM" src="https://user-images.githubusercontent.com/2528959/97658156-02149880-1a42-11eb-9e78-3a359afaca99.png">

**After**

<img width="1074" alt="Screen Shot 2020-10-29 at 11 53 16 PM" src="https://user-images.githubusercontent.com/2528959/97658244-3b4d0880-1a42-11eb-8914-3d642ad41396.png">

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

- Needs some way to test this
