### PR TITLE
refactor: optimise session data structures

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -127,8 +127,7 @@ def pytest_collection_modifyitems(
     After tests are collected and before any modification is performed.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_collection_modifyitems
     """
-    for item in config._syrupy.filter_valid_items(items):
-        config._syrupy._all_items[item] = True
+    config._syrupy.collect_items(items)
 
 
 def pytest_collection_finish(session: Any) -> None:
@@ -136,8 +135,7 @@ def pytest_collection_finish(session: Any) -> None:
     After collection has been performed and modified.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_collection_finish
     """
-    for item in session.config._syrupy.filter_valid_items(session.items):
-        session.config._syrupy._ran_items[item] = False
+    session.config._syrupy.select_items(session.items)
 
 
 def pytest_runtest_logfinish(nodeid: str) -> None:
@@ -146,12 +144,8 @@ def pytest_runtest_logfinish(nodeid: str) -> None:
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_runtest_logfinish
     """
     global _syrupy
-    if not _syrupy:
-        return
-    for item in _syrupy._ran_items:
-        if getattr(item, "nodeid", None) == nodeid:
-            _syrupy._ran_items[item] = True
-            return
+    if _syrupy:
+        _syrupy.ran_item(nodeid)
 
 
 def pytest_sessionfinish(session: Any, exitstatus: int) -> None:

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -164,6 +164,14 @@ class SnapshotReport:
         return self._collected_items_by_nodeid.keys() == self.selected_items.keys()
 
     @property
+    def ran_items(self) -> Iterator["pytest.Item"]:
+        return (
+            self._collected_items_by_nodeid[nodeid]
+            for nodeid in self.selected_items
+            if self.selected_items[nodeid]
+        )
+
+    @property
     def unused(self) -> "SnapshotFossils":
         """
         Iterate over each snapshot that was discovered but never used and compute
@@ -362,11 +370,8 @@ class SnapshotReport:
         Check that a snapshot name would match a test node using the Pytest location
         """
         return any(
-            PyTestLocation(
-                self._collected_items_by_nodeid[nodeid]
-            ).matches_snapshot_name(snapshot_name)
-            for nodeid in self.selected_items
-            if self.selected_items[nodeid]
+            PyTestLocation(item).matches_snapshot_name(snapshot_name)
+            for item in self.ran_items
         )
 
     def _selected_items_match_name(self, snapshot_name: str) -> bool:
@@ -380,16 +385,13 @@ class SnapshotReport:
 
     def _ran_items_match_location(self, snapshot_location: str) -> bool:
         """
-        Check that a snapshot fossil location should is selected by the current session
+        Check if any test run in the current session should match the snapshot location
         This being true means that if no snapshot in the fossil was used then it should
         be discarded as obsolete
         """
         return any(
-            PyTestLocation(
-                self._collected_items_by_nodeid[nodeid]
-            ).matches_snapshot_location(snapshot_location)
-            for nodeid in self.selected_items
-            if self.selected_items[nodeid]
+            PyTestLocation(item).matches_snapshot_location(snapshot_location)
+            for item in self.ran_items
         )
 
 

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -5,6 +5,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Set,
     Tuple,
 )
 
@@ -28,25 +29,42 @@ class SnapshotSession:
     _invocation_args: Tuple[str, ...] = attr.ib(factory=tuple)
     report: Optional["SnapshotReport"] = attr.ib(default=None)
     # All the collected test items
-    _all_items: Dict["pytest.Item", bool] = attr.ib(factory=dict)
+    _collected_items: Set["pytest.Item"] = attr.ib(factory=set)
     # All the selected test items. Will be set to False until the test item is run.
-    _ran_items: Dict["pytest.Item", bool] = attr.ib(factory=dict)
+    _selected_items: Dict["pytest.Item", bool] = attr.ib(factory=dict)
+    # Used to optimise the look up of selected test items when marking them as ran.
+    _selected_items_by_nodeid: Dict[str, "pytest.Item"] = attr.ib(
+        factory=dict, init=False
+    )
     _assertions: List["SnapshotAssertion"] = attr.ib(factory=list)
     _extensions: Dict[str, "AbstractSyrupyExtension"] = attr.ib(factory=dict)
 
+    def collect_items(self, items: List["pytest.Item"]) -> None:
+        self._collected_items.update(self.filter_valid_items(items))
+
+    def select_items(self, items: List["pytest.Item"]) -> None:
+        for item in self.filter_valid_items(items):
+            self._selected_items[item] = False
+            nodeid = getattr(item, "nodeid", None)
+            self._selected_items_by_nodeid[nodeid] = item
+
     def start(self) -> None:
         self.report = None
-        self._all_items = {}
-        self._ran_items = {}
+        self._collected_items = set()
+        self._selected_items = {}
         self._assertions = []
         self._extensions = {}
+
+    def ran_item(self, nodeid: str) -> None:
+        if nodeid in self._selected_items_by_nodeid:
+            self._selected_items[self._selected_items_by_nodeid[nodeid]] = True
 
     def finish(self) -> int:
         exitstatus = 0
         self.report = SnapshotReport(
             base_dir=self.base_dir,
-            all_items=self._all_items,
-            ran_items=self._ran_items,
+            collected_items=self._collected_items,
+            selected_items=self._selected_items,
             assertions=self._assertions,
             update_snapshots=self.update_snapshots,
             warn_unused_snapshots=self.warn_unused_snapshots,

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -31,11 +31,7 @@ class SnapshotSession:
     # All the collected test items
     _collected_items: Set["pytest.Item"] = attr.ib(factory=set)
     # All the selected test items. Will be set to False until the test item is run.
-    _selected_items: Dict["pytest.Item", bool] = attr.ib(factory=dict)
-    # Used to optimise the look up of selected test items when marking them as ran.
-    _selected_items_by_nodeid: Dict[str, "pytest.Item"] = attr.ib(
-        factory=dict, init=False
-    )
+    _selected_items: Dict[str, bool] = attr.ib(factory=dict)
     _assertions: List["SnapshotAssertion"] = attr.ib(factory=list)
     _extensions: Dict[str, "AbstractSyrupyExtension"] = attr.ib(factory=dict)
 
@@ -44,9 +40,7 @@ class SnapshotSession:
 
     def select_items(self, items: List["pytest.Item"]) -> None:
         for item in self.filter_valid_items(items):
-            self._selected_items[item] = False
-            nodeid = getattr(item, "nodeid", None)
-            self._selected_items_by_nodeid[nodeid] = item
+            self._selected_items[getattr(item, "nodeid", None)] = False
 
     def start(self) -> None:
         self.report = None
@@ -56,8 +50,7 @@ class SnapshotSession:
         self._extensions = {}
 
     def ran_item(self, nodeid: str) -> None:
-        if nodeid in self._selected_items_by_nodeid:
-            self._selected_items[self._selected_items_by_nodeid[nodeid]] = True
+        self._selected_items[nodeid] = True
 
     def finish(self) -> int:
         exitstatus = 0


### PR DESCRIPTION
## Description

- Removes unnecessary use of dict in the session/report for tracking all test items
- Renames ran items to selected items, just more semantically accurate
- Move test collection logic into the session instance

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
