### PR TITLE
build: do not install local version of syrupy in dev env

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,7 +25,7 @@ if [[ -z $SKIP_DEPS ]]; then
     if [[ -z $CI ]]; then
         export PYTHONPATH="./src:$PYTHONPATH"
     else
-        python -m pip install -e .
+        python -m pip install -e . --no-deps
     fi
     python -m pip install -r dev_requirements.txt
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -22,7 +22,12 @@ test -d $VENV || python3 -m venv $VENV || return
 python -m pip install -U pip --no-cache-dir
 
 if [[ -z $SKIP_DEPS ]]; then
-    python -m pip install -e . -r dev_requirements.txt
+    if [[ -z $CI ]]; then
+        export PYTHONPATH="./src:$PYTHONPATH"
+    else
+        python -m pip install -e .
+    fi
+    python -m pip install -r dev_requirements.txt
 fi
 
 if [[ -z $CI ]]; then


### PR DESCRIPTION
## Description

This allows the local test to be run against the current code rather than the installed version after boostrapping

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
