### PR TITLE
feat: add PEP-561 py.typed file for downstream type checkers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ if __name__ in ["__main__", "builtins"]:
             "write_to": "version.txt",
         },
         package_dir={"": "src"},
+        package_data={"": ["py.typed"]},
         packages=find_packages("./src"),
         zip_safe=False,
         entry_points={"pytest11": ["syrupy = syrupy"]},


### PR DESCRIPTION
## Description

This follows PEP-561 to mark syrupy as compatible with type
checking (driven by the type annotations that already exist and are
checked), by creating an empty `py.typed` in the project. This stops
users from having to ignore syrupy when type checking, and allows the
type checker to provide specific guidance about possible problems.

See https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages for more information about this approach.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #439, discussing the value for type checking

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
