### PR TITLE
fix(report): correctly use pytest invocation arguments

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -115,17 +115,10 @@ def pytest_sessionstart(session: Any) -> None:
     Initialize snapshot session before tests are collected and ran.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionstart
     """
-    config = session.config
-    config._syrupy = SnapshotSession(
-        warn_unused_snapshots=config.option.warn_unused_snapshots,
-        update_snapshots=config.option.update_snapshots,
-        include_snapshot_details=config.option.include_snapshot_details,
-        base_dir=config.rootdir,
-        invocation_args=config.invocation_params.args,
-    )
+    session.config._syrupy = SnapshotSession(pytest_session=session)
     global _syrupy
-    _syrupy = config._syrupy
-    config._syrupy.start()
+    _syrupy = session.config._syrupy
+    session.config._syrupy.start()
 
 
 def pytest_collection_modifyitems(

--- a/tests/integration/test_snapshot_option_update.py
+++ b/tests/integration/test_snapshot_option_update.py
@@ -315,7 +315,7 @@ def test_update_targets_only_selected_module_tests_nodes(run_testcases):
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
     testfile = Path(testdir.tmpdir, "test_used.py")
-    result = testdir.runpytest(f"{testfile}::test_used", "-v", "--snapshot-update")
+    result = testdir.runpytest("-v", f"{testfile}::test_used", "--snapshot-update")
     result.stdout.re_match_lines((r"3 snapshots passed\."))
     assert "unused" not in result.stdout.str()
     assert "updated" not in result.stdout.str()
@@ -357,7 +357,7 @@ def test_update_targets_only_selected_module_tests_file_for_update(run_testcases
             """
         )
     )
-    result = testdir.runpytest("-v", "--snapshot-update", "test_used.py")
+    result = testdir.runpytest("-v", "test_used.py", "--snapshot-update")
     result.stdout.re_match_lines(
         (
             r"3 snapshots passed\. 2 unused snapshots deleted\.",
@@ -381,7 +381,7 @@ def test_update_targets_only_selected_module_tests_file_for_removal(run_testcase
     )
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
-    result = testdir.runpytest("-v", "--snapshot-update", "test_used.py")
+    result = testdir.runpytest("-v", "test_used.py", "--snapshot-update")
     result.stdout.re_match_lines(
         (
             r"5 unused snapshots deleted\.",


### PR DESCRIPTION
## Description

Correct usage of pytest invocation arguments

### Example

```sh
$ pytest --ff tests/syrupy/extensions/amber/test_amber_serializer.py
===================================== test session starts ======================================
platform darwin -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/Emmanuel/Sources/github/tophat/syrupy, configfile: pyproject.toml
plugins: syrupy-2021.5.31.224541039469
collected 57 items                                                                             
run-last-failure: no previously failed tests, not deselecting items.

tests/syrupy/extensions/amber/test_amber_serializer.py ................................. [ 57%]
........................                                                                 [100%]

----------------------------------- snapshot report summary ------------------------------------
69 snapshots passed. 8 snapshots unused.

Re-run pytest with --snapshot-update to delete unused snapshots.
====================================== 57 passed in 0.44s ======================================
```

**Snapshots marked as unused**: due to wrong parsing of invocation arguments

Also see modified failing tests.

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

N/A
