### PR TITLE
feat(types): explicit property matcher and filter types kwargs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from syrupy.utils import env_context
 
-typing.TYPE_CHECKING = True
+typing.TYPE_CHECKING = False
 pytest_plugins = "pytester"
 
 

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -161,10 +161,8 @@ class SnapshotAssertion:
             self.__with_prop("_matcher", matcher)
         return self
 
-    def __repr__(self) -> str:
-        attrs_to_repr = ["name", "num_executions"]
-        attrs_repr = ", ".join(f"{a}={repr(getattr(self, a))}" for a in attrs_to_repr)
-        return f"SnapshotAssertion({attrs_repr})"
+    def __dir__(self) -> List[str]:
+        return ["name", "num_executions"]
 
     def __eq__(self, other: "SerializableData") -> bool:
         return self._assert(other)

--- a/src/syrupy/extensions/amber/__init__.py
+++ b/src/syrupy/extensions/amber/__init__.py
@@ -18,14 +18,6 @@ if TYPE_CHECKING:
 class AmberSnapshotExtension(AbstractSyrupyExtension):
     """
     An amber snapshot file stores data in the following format:
-
-    ```
-    # name: test_name_1
-      data
-    ---
-    # name: test_name_2
-      data
-    ```
     """
 
     def serialize(self, data: "SerializableData", **kwargs: Any) -> str:

--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -45,8 +45,9 @@ class Repr:
 class DataSerializer:
     _indent: str = "  "
     _max_depth: int = 99
+    _marker_comment: str = "# "
     _marker_divider: str = "---"
-    _marker_name: str = "# name:"
+    _marker_name: str = f"{_marker_comment}name:"
     _marker_crn: str = "\r\n"
 
     @classmethod

--- a/src/syrupy/filters.py
+++ b/src/syrupy/filters.py
@@ -13,7 +13,7 @@ def paths(path_string: str, *path_strings: str) -> "PropertyFilter":
     Factory to create a filter using list of paths
     """
 
-    def path_filter(prop: "PropertyName", path: "PropertyPath") -> bool:
+    def path_filter(*, prop: "PropertyName", path: "PropertyPath") -> bool:
         path_str = ".".join(str(p) for p, _ in (*path, (prop, None)))
         return any(path_str == p for p in (path_string, *path_strings))
 
@@ -25,7 +25,7 @@ def props(prop_name: str, *prop_names: str) -> "PropertyFilter":
     Factory to create filter using list of props
     """
 
-    def prop_filter(prop: "PropertyName", path: "PropertyPath") -> bool:
+    def prop_filter(*, prop: "PropertyName", path: "PropertyPath") -> bool:
         return any(str(prop) == p for p in (prop_name, *prop_names))
 
     return prop_filter

--- a/src/syrupy/matchers.py
+++ b/src/syrupy/matchers.py
@@ -37,7 +37,7 @@ def path_type(
         raise PathTypeError(gettext("Both mapping and types argument cannot be empty"))
 
     def path_type_matcher(
-        data: "SerializableData", path: "PropertyPath"
+        *, data: "SerializableData", path: "PropertyPath"
     ) -> Optional["SerializableData"]:
         path_str = ".".join(str(p) for p, _ in path)
         if mapping:

--- a/src/syrupy/types.py
+++ b/src/syrupy/types.py
@@ -1,6 +1,5 @@
 from typing import (
     Any,
-    Callable,
     Hashable,
     Optional,
     Tuple,
@@ -14,5 +13,24 @@ PropertyName = Hashable
 PropertyValueType = Type[SerializableData]
 PropertyPathEntry = Tuple[PropertyName, PropertyValueType]
 PropertyPath = Tuple[PropertyPathEntry, ...]
-PropertyMatcher = Callable[..., Optional[SerializableData]]
-PropertyFilter = Callable[..., bool]
+try:
+    # Python minimum version 3.8
+    # https://docs.python.org/3/library/typing.html#typing.Protocol
+    from typing import Protocol
+
+    class PropertyMatcher(Protocol):
+        def __call__(
+            self,
+            *,
+            data: "SerializableData",
+            path: "PropertyPath",
+        ) -> Optional["SerializableData"]:
+            ...
+
+    class PropertyFilter(Protocol):
+        def __call__(self, *, prop: "PropertyName", path: "PropertyPath") -> bool:
+            ...
+
+
+except ImportError:
+    pass

--- a/tests/syrupy/extensions/amber/__snapshots__/test_amber_serializer.ambr
+++ b/tests/syrupy/extensions/amber/__snapshots__/test_amber_serializer.ambr
@@ -136,6 +136,11 @@
 ---
 # name: test_dict[actual2]
   <class 'dict'> {
+    '
+      multi
+      line
+      key
+    ': 'Some morre text.',
     'a': 'Some ttext.',
     1: True,
     <class 'ExampleTuple'> (
@@ -309,7 +314,10 @@
   'value.with.dot'
 ---
 # name: test_reflection
-  SnapshotAssertion(name='snapshot', num_executions=0)
+  <class 'SnapshotAssertion'> {
+    name='snapshot',
+    num_executions=0,
+  }
 ---
 # name: test_set[actual0]
   <class 'set'> {
@@ -354,6 +362,14 @@
 # name: test_set[actual4]
   <class 'set'> {
   }
+---
+# name: test_snapshot_markers
+  '
+  # 
+    # 
+  ---
+  # name:
+  '
 ---
 # name: test_string[0]
   ''

--- a/tests/syrupy/extensions/amber/test_amber_serializer.py
+++ b/tests/syrupy/extensions/amber/test_amber_serializer.py
@@ -2,6 +2,8 @@ from collections import namedtuple
 
 import pytest
 
+from syrupy.extensions.amber.serializer import DataSerializer
+
 
 def test_non_snapshots(snapshot):
     with pytest.raises(AssertionError):
@@ -15,6 +17,19 @@ def test_reflection(snapshot):
 def test_empty_snapshot(snapshot):
     assert snapshot == None  # noqa: E711
     assert snapshot == ""
+
+
+def test_snapshot_markers(snapshot):
+    """
+    Test snapshot markers do not break serialization when in snapshot data
+    """
+    marker_strings = (
+        DataSerializer._marker_comment,
+        f"{DataSerializer._indent}{DataSerializer._marker_comment}",
+        DataSerializer._marker_divider,
+        DataSerializer._marker_name,
+    )
+    assert snapshot == "\n".join(marker_strings)
 
 
 def test_newline_control_characters(snapshot):
@@ -100,6 +115,7 @@ def test_set(snapshot, actual):
         {
             1: True,
             "a": "Some ttext.",
+            "multi\nline\nkey": "Some morre text.",
             frozenset({"1", "2"}): ["1", 2],
             ExampleTuple(a=1, b=2, c=3, d=4): {"e": False},
         },


### PR DESCRIPTION
## Description

* Improves the typing of `PropertyMatcher` and `PropertyFilter`
* Makes `DataSerializer` methods explicit about accepted types

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
