### PR TITLE
feat: support snapshots in doc tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,10 @@ dist,
 '''
 
 [tool.pytest.ini_options]
-addopts = '-p syrupy'
+addopts = '-p syrupy --doctest-modules'
+testpaths = [
+  "tests",
+]
 
 [tool.coverage.run]
 source = ['./src']

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -19,7 +19,7 @@ fi
 if [[ -z $CI ]]; then
     # FIXME: There must be a better way to install this per project rather than globally?
     curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0a2
-    poetry shell
+    . ./.venv/bin/activate
 fi
 
 if [[ -z $SKIP_DEPS ]]; then

--- a/tests/syrupy/__snapshots__/test_doctest.ambr
+++ b/tests/syrupy/__snapshots__/test_doctest.ambr
@@ -1,0 +1,37 @@
+# name: DocTestClass
+  DocTestClass(
+    obj_attr='test class attr',
+  )
+# ---
+# name: DocTestClass.1
+  DocTestClass(
+    obj_attr='test class attr',
+  )
+# ---
+# name: DocTestClass.NestedDocTestClass
+  NestedDocTestClass(
+    nested_obj_attr='nested doc test class attr',
+  )
+# ---
+# name: DocTestClass.NestedDocTestClass.doctest_method
+  'nested doc test method return value'
+# ---
+# name: DocTestClass.doctest_method
+  'doc test method return value'
+# ---
+# name: doctest_fn
+  'doc test fn return value'
+# ---
+# name: test_doctest.txt
+  'There must be a break after every snapshot assertion'
+# ---
+# name: test_doctest.txt.1
+  'constant value'
+# ---
+# name: test_doctest.txt.2
+  set({
+    1,
+    2,
+    3,
+  })
+# ---

--- a/tests/syrupy/test_doctest.py
+++ b/tests/syrupy/test_doctest.py
@@ -1,0 +1,42 @@
+def doctest_fn():
+    """a doctest in a function docstring
+    >>> doctest_fn() == getfixture('snapshot')
+    True
+    """
+    return "doc test fn return value"
+
+
+class DocTestClass:
+    """
+    >>> DocTestClass() == getfixture('snapshot')
+    True
+
+    a doctest in a class docstring
+    >>> DocTestClass() == getfixture('snapshot')
+    True
+    """
+
+    obj_attr = "test class attr"
+
+    def doctest_method(self):
+        """a doctest in a method docstring
+        >>> DocTestClass().doctest_method() == getfixture('snapshot')
+        True
+        """
+        return "doc test method return value"
+
+    class NestedDocTestClass:
+        """a doctest in a nested class docstring
+        >>> DocTestClass.NestedDocTestClass() == getfixture('snapshot')
+        True
+        """
+
+        nested_obj_attr = "nested doc test class attr"
+
+        def doctest_method(self):
+            """a doctest in a nested method docstring
+            >>> nested_obj = DocTestClass.NestedDocTestClass()
+            >>> nested_obj.doctest_method() == getfixture('snapshot')
+            True
+            """
+            return "nested doc test method return value"

--- a/tests/syrupy/test_doctest.txt
+++ b/tests/syrupy/test_doctest.txt
@@ -1,0 +1,14 @@
+>>> "There must be a break after every snapshot assertion" == getfixture('snapshot')
+True
+
+doctest x
+
+doctest y
+>>> y = "constant value"
+>>> y == getfixture('snapshot')
+True
+
+doctest z
+>>> z = {1, 2, 3}
+>>> z == getfixture('snapshot')
+True


### PR DESCRIPTION
## Description

Handles snapshotting in doc tests.
* Enable running doc tests in syrupy ci
* Update bootstrap script to source new venv

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- From #451, error in report generation when running doctests.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

* https://docs.python.org/3/library/doctest.html#doctest-objects
* https://docs.pytest.org/en/6.2.x/doctest.html
