### PR TITLE
feat: add snapshot diffing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,23 @@ def test_foo(snapshot):
     assert actual_svg == snapshot(extension_class=SVGImageSnapshotExtension)
 ```
 
+#### `diff`
+
+This is an option to snapshot only the diff between the actual object and a previous snapshot, with the `diff` argument being the previous snapshot `index`/`name`.
+
+```py
+def test_diff(snapshot):
+    actual0 = [1,2,3,4]
+    actual1 = [0,1,3,4]
+
+    assert actual0 == snapshot
+    assert actual1 == snapshot(diff=0)
+    # This is equivalent to the lines above
+    # Must use the index name to diff when given
+    assert actual0 == snapshot(name='snap_name')
+    assert actual1 == snapshot(diff='snap_name')
+```
+
 ##### Built-In Extensions
 
 Syrupy comes with a few built-in preset configurations for you to choose from. You should also feel free to extend the `AbstractSyrupyExtension` if your project has a need not captured by one our built-ins.
@@ -295,7 +312,7 @@ from syrupy.extensions.json import JSONSnapshotExtension
 
 @pytest.fixture
 def snapshot_json(snapshot):
-    return snapshot.use_extension(JSONSnapshotExtension) 
+    return snapshot.use_extension(JSONSnapshotExtension)
 
 
 def test_api_call(client, snapshot_json):
@@ -399,6 +416,5 @@ This section is automatically generated via tagging the all-contributors bot in 
 ```
 
 ## License
-
 
 Syrupy is licensed under [Apache License Version 2.0](https://github.com/tophat/syrupy/tree/master/LICENSE).

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -12,7 +12,6 @@ from typing import (
     List,
     Optional,
     Type,
-    Union,
 )
 
 from .exceptions import SnapshotDoesNotExist
@@ -109,7 +108,7 @@ class SnapshotAssertion:
         return self._execution_results
 
     @property
-    def index(self) -> Union[str, int]:
+    def index(self) -> "SnapshotIndex":
         if self._custom_index:
             return self._custom_index
         return self.num_executions

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         PropertyMatcher,
         SerializableData,
         SerializedData,
+        SnapshotIndex,
     )
 
 
@@ -169,10 +170,11 @@ class SnapshotAssertion:
     def __call__(
         self,
         *,
+        diff: Optional["SnapshotIndex"] = None,
         exclude: Optional["PropertyFilter"] = None,
         extension_class: Optional[Type["AbstractSyrupyExtension"]] = None,
         matcher: Optional["PropertyMatcher"] = None,
-        name: Optional[str] = None,
+        name: Optional["SnapshotIndex"] = None,
     ) -> "SnapshotAssertion":
         """
         Modifies assertion instance options
@@ -185,6 +187,8 @@ class SnapshotAssertion:
             self.__with_prop("_matcher", matcher)
         if name:
             self.__with_prop("_custom_index", name)
+        if diff is not None:
+            self.__with_prop("_snapshot_diff", diff)
         return self
 
     def __dir__(self) -> List[str]:
@@ -202,8 +206,17 @@ class SnapshotAssertion:
         assertion_success = False
         assertion_exception = None
         try:
-            snapshot_data = self._recall_data()
+            snapshot_data = self._recall_data(index=self.index)
             serialized_data = self._serialize(data)
+            snapshot_diff = getattr(self, "_snapshot_diff", None)
+            if snapshot_diff is not None:
+                snapshot_data_diff = self._recall_data(index=snapshot_diff)
+                if snapshot_data_diff is None:
+                    raise SnapshotDoesNotExist()
+                serialized_data = self.extension.diff_snapshots(
+                    serialized_data=serialized_data,
+                    snapshot_data=snapshot_data_diff,
+                )
             matches = snapshot_data is not None and self.extension.matches(
                 serialized_data=serialized_data, snapshot_data=snapshot_data
             )
@@ -241,8 +254,8 @@ class SnapshotAssertion:
         while self._post_assert_actions:
             self._post_assert_actions.pop()()
 
-    def _recall_data(self) -> Optional["SerializableData"]:
+    def _recall_data(self, index: "SnapshotIndex") -> Optional["SerializableData"]:
         try:
-            return self.extension.read_snapshot(index=self.index)
+            return self.extension.read_snapshot(index=index)
         except SnapshotDoesNotExist:
             return None

--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -1,6 +1,9 @@
 import functools
 import os
-from types import GeneratorType
+from types import (
+    GeneratorType,
+    MappingProxyType,
+)
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -163,7 +166,7 @@ class DataSerializer:
             serialize_method = cls.serialize_number
         elif isinstance(data, (set, frozenset)):
             serialize_method = cls.serialize_set
-        elif isinstance(data, dict):
+        elif isinstance(data, (dict, MappingProxyType)):
             serialize_method = cls.serialize_dict
         elif cls.__is_namedtuple(data):
             serialize_method = cls.serialize_namedtuple

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -4,7 +4,6 @@ from typing import (
     TYPE_CHECKING,
     Optional,
     Set,
-    Union,
 )
 from unicodedata import category
 
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
         PropertyMatcher,
         SerializableData,
         SerializedData,
+        SnapshotIndex,
     )
 
 
@@ -34,7 +34,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     ) -> "SerializedData":
         return bytes(data)
 
-    def get_snapshot_name(self, *, index: Union[str, int] = 0) -> str:
+    def get_snapshot_name(self, *, index: "SnapshotIndex" = 0) -> str:
         return self.__clean_filename(
             super(SingleFileSnapshotExtension, self).get_snapshot_name(index=index)
         )
@@ -48,7 +48,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     def _file_extension(self) -> str:
         return "raw"
 
-    def _get_file_basename(self, *, index: Union[str, int]) -> str:
+    def _get_file_basename(self, *, index: "SnapshotIndex") -> str:
         return self.get_snapshot_name(index=index)
 
     @property

--- a/src/syrupy/types.py
+++ b/src/syrupy/types.py
@@ -8,6 +8,7 @@ from typing import (
     Union,
 )
 
+SnapshotIndex = Union[int, str]
 SerializableData = Any
 SerializedData = Union[str, bytes]
 PropertyName = Hashable

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import (
     Any,
+    Dict,
     Iterator,
 )
 
@@ -66,3 +67,17 @@ def env_context(**kwargs: str) -> Iterator[None]:
     finally:
         os.environ.clear()
         os.environ.update(prev_env)
+
+
+def set_attrs(obj: Any, attrs: Dict[str, Any]) -> Any:
+    for k in attrs:
+        setattr(obj, k, attrs[k])
+
+
+@contextmanager
+def obj_attrs(obj: Any, attrs: Dict[str, Any]) -> Iterator[None]:
+    prev_attrs = {k: getattr(obj, k, None) for k in attrs}
+    try:
+        yield set_attrs(obj, attrs)
+    finally:
+        set_attrs(obj, prev_attrs)

--- a/tests/examples/test_custom_snapshot_name.py
+++ b/tests/examples/test_custom_snapshot_name.py
@@ -1,15 +1,14 @@
 """
 Example: Custom Snapshot Name
 """
-from typing import Union
-
 import pytest
 
 from syrupy.extensions.amber import AmberSnapshotExtension
+from syrupy.types import SnapshotIndex
 
 
 class CanadianNameExtension(AmberSnapshotExtension):
-    def get_snapshot_name(self, *, index: Union[str, int]) -> str:
+    def get_snapshot_name(self, *, index: "SnapshotIndex") -> str:
         original_name = super(CanadianNameExtension, self).get_snapshot_name(
             index=index
         )

--- a/tests/syrupy/extensions/amber/__snapshots__/test_amber_snapshot_diff.ambr
+++ b/tests/syrupy/extensions/amber/__snapshots__/test_amber_snapshot_diff.ambr
@@ -1,0 +1,112 @@
+# name: test_snapshot_diff
+  dict({
+    'field_0': True,
+    'field_1': 'no_value',
+    'nested': dict({
+      'field_0': 1,
+    }),
+  })
+# ---
+# name: test_snapshot_diff.1
+      ...
+  -   'field_1': 'no_value',
+  +   'field_1': 'yes_value',
+      ...
+# ---
+# name: test_snapshot_diff.2
+      ...
+  -   'field_1': 'no_value',
+  +   'field_1': 'yes_value',
+      ...
+  -     'field_0': 1,
+  +     'field_0': 2,
+    ...
+# ---
+# name: test_snapshot_diff_id.1
+      ...
+  -   'field_1': 'no_value',
+  +   'field_1': 'yes_value',
+      ...
+  -     True,
+        ...
+  -     None,
+  +     False,
+      ...
+  -     'no',
+  +     'yes',
+  -     False,
+  +     0,
+      ...
+# ---
+# name: test_snapshot_diff_id[case3]
+        ...
+  -   'nested_0': dict({
+  +   'nested_0': mappingproxy({
+  -     'field_0': True,
+  +     'field_0': 2,
+          ...
+  -   'nested_1': dict({
+  +   'nested_1': mappingproxy({
+  -     'field_0': True,
+  +     'field_0': 2,
+          ...
+# ---
+# name: test_snapshot_diff_id[large snapshot]
+  dict({
+    'field_0': True,
+    'field_1': 'no_value',
+    'field_2': 0,
+    'field_3': None,
+    'field_4': 1,
+    'field_5': False,
+    'field_6': tuple(
+      True,
+      'hey',
+      2,
+      None,
+    ),
+    'field_7': set({
+      'no',
+      False,
+      None,
+    }),
+    'nested_0': dict({
+      'field_0': True,
+      'field_1': 'no_value',
+      'field_2': 0,
+      'field_3': None,
+      'field_4': 1,
+      'field_5': False,
+      'field_6': tuple(
+        True,
+        'hey',
+        2,
+        None,
+      ),
+      'field_7': set({
+        'no',
+        False,
+        None,
+      }),
+    }),
+    'nested_1': dict({
+      'field_0': True,
+      'field_1': 'no_value',
+      'field_2': 0,
+      'field_3': None,
+      'field_4': 1,
+      'field_5': False,
+      'field_6': tuple(
+        True,
+        'hey',
+        2,
+        None,
+      ),
+      'field_7': set({
+        'no',
+        False,
+        None,
+      }),
+    }),
+  })
+# ---

--- a/tests/syrupy/extensions/amber/test_amber_snapshot_diff.py
+++ b/tests/syrupy/extensions/amber/test_amber_snapshot_diff.py
@@ -1,0 +1,64 @@
+from types import MappingProxyType
+
+import pytest
+
+
+def test_snapshot_diff(snapshot):
+    my_dict = {
+        "field_0": True,
+        "field_1": "no_value",
+        "nested": {
+            "field_0": 1,
+        },
+    }
+    assert my_dict == snapshot
+    my_dict["field_1"] = "yes_value"
+    assert my_dict == snapshot(diff=0)
+    my_dict["nested"]["field_0"] = 2
+    assert my_dict == snapshot(diff=0)
+
+
+def test_snapshot_diff_id(snapshot):
+    my_dict = {
+        "field_0": True,
+        "field_1": "no_value",
+        "field_2": 0,
+        "field_3": None,
+        "field_4": 1,
+        "field_5": False,
+        "field_6": (True, "hey", 2, None),
+        "field_7": {False, "no", 0, None},
+    }
+    dictLargeSnapshot = dict(
+        {
+            **my_dict,
+            "nested_0": dict(my_dict),
+            "nested_1": dict(my_dict),
+        }
+    )
+    assert dictLargeSnapshot == snapshot(name="large snapshot")
+    dictDiffLargeSnapshot = dict(
+        {
+            **dictLargeSnapshot,
+            "field_1": "yes_value",
+            "field_6": ("hey", 2, False),
+            "field_7": {"yes", 0, None},
+        }
+    )
+    assert dictDiffLargeSnapshot == snapshot(diff="large snapshot")
+    dictCase3 = dict(
+        {
+            **dictLargeSnapshot,
+            "nested_0": MappingProxyType({**my_dict, "field_0": 2}),
+            "nested_1": MappingProxyType({**my_dict, "field_0": 2}),
+        }
+    )
+    assert dictCase3 == snapshot(name="case3", diff="large snapshot")
+
+
+def test_snapshot_no_diff_raises_exception(snapshot):
+    my_dict = {
+        "field_0": "value_0",
+    }
+    with pytest.raises(AssertionError, match="SnapshotDoesNotExist"):
+        assert my_dict == snapshot(diff="does not exist index")


### PR DESCRIPTION
## Description

Adds snapshot naming and diffing support to promote committing short focused snapshot assertions.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #161, snapshot diffing.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

Review the diff representation
