### PR TITLE
perf: memoise DataSerializer.read_file results

### DIFF
--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -1,3 +1,4 @@
+import functools
 import os
 from types import GeneratorType
 from typing import (
@@ -12,7 +13,6 @@ from typing import (
     Tuple,
     Union,
 )
-import functools
 
 from syrupy.constants import SYMBOL_ELLIPSIS
 from syrupy.data import (
@@ -80,7 +80,7 @@ class DataSerializer:
                     f.write(f"\n{cls._marker_divider}\n")
 
     @classmethod
-    @functools.lru_cache
+    @functools.lru_cache()
     def read_file(cls, filepath: str) -> "SnapshotFossil":
         """
         Read the raw snapshot data (str) from the snapshot file into a dict

--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -12,6 +12,7 @@ from typing import (
     Tuple,
     Union,
 )
+import functools
 
 from syrupy.constants import SYMBOL_ELLIPSIS
 from syrupy.data import (
@@ -79,6 +80,7 @@ class DataSerializer:
                     f.write(f"\n{cls._marker_divider}\n")
 
     @classmethod
+    @functools.lru_cache
     def read_file(cls, filepath: str) -> "SnapshotFossil":
         """
         Read the raw snapshot data (str) from the snapshot file into a dict


### PR DESCRIPTION
## Description

This applies the `functools.lru_cache` memoising decorator to the low level `amber.DataSerializer.read_file` method, which dramatically improves performance by avoiding re-reading a single snapshot file dozens of times, thus eliminating the quadratic behaviour observed in #539 in the common case of read-only interaction with amber snapshots.

For the test in #539, with a single snapshot test parametrised with `SIZE` instances (note that doubling the size now doubles the time):

| SIZE | before (1.43) time (s) | after (this PR) time (s) |
|---|---|---|
| 100 | 0.09 | 0.07 | 
| 500 | 0.75 | 0.29 |
| 1000 | 2.42 | 0.51 |
| 2000 | 8.24 | 0.98 |
| 10000 | 201 | 4.64 |

For our real-world test suite, with 453 snapshots across 25 files:

| syrupy version | time (s) |
|---|---|
| 1.4.1 (original) | 68 |
| 1.4.2 | 51 |
| 1.4.3 | 35 |
| this PR | 30 |

This has to be on this `DataSerializer` class method, rather than the higher level methods in `AmberSnapshotExtension` because the methods there are instance methods, with a `self` argument, and it's called on different instances (and thus end up as different `lru_cache` entries).

This optimisation is limited to only reading the amber file types, but I think images (and other single-file snapshots) will not have the same quadratic issues, and writing is arguably much less common than reading.

## Related Issues

- #539

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
