### PR TITLE
feat: allow extensions to override snapshot equality check

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -178,7 +178,9 @@ class SnapshotAssertion:
         try:
             snapshot_data = self._recall_data(index=self.num_executions)
             serialized_data = self._serialize(data)
-            matches = snapshot_data is not None and serialized_data == snapshot_data
+            matches = snapshot_data is not None and self.extension.matches(
+                serialized_data=serialized_data, snapshot_data=snapshot_data
+            )
             assertion_success = matches
             if not matches and self._update_snapshots:
                 self.extension.write_snapshot(

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -371,7 +371,23 @@ class SnapshotReporter(ABC):
         return line.rstrip("".join(self._ends.keys()))
 
 
-class AbstractSyrupyExtension(SnapshotSerializer, SnapshotFossilizer, SnapshotReporter):
+class SnapshotComparator(ABC):
+    def matches(
+        self,
+        *,
+        serialized_data: "SerializableData",
+        snapshot_data: "SerializableData",
+    ) -> bool:
+        """
+        Compares serialized data and snapshot data and returns
+        whether they match.
+        """
+        return bool(serialized_data == snapshot_data)
+
+
+class AbstractSyrupyExtension(
+    SnapshotSerializer, SnapshotFossilizer, SnapshotReporter, SnapshotComparator
+):
     def __init__(self, test_location: "PyTestLocation"):
         self._test_location = test_location
 


### PR DESCRIPTION
## Description

Allow extensions to override snapshot equality check. This is to enable adding "tolerance" to the check, as well as to satisfy use cases such as visual regression testing.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Related to https://github.com/tophat/syrupy/discussions/536

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
