### PR TITLE
fix(json): Use additional forward references for py3.7

### DIFF
--- a/src/syrupy/extensions/json/__init__.py
+++ b/src/syrupy/extensions/json/__init__.py
@@ -54,9 +54,9 @@ class JSONSnapshotExtension(SingleFileSnapshotExtension):
         data: "SerializableData",
         *,
         depth: int = 0,
-        path: PropertyPath,
+        path: "PropertyPath",
         exclude: Optional["PropertyFilter"] = None,
-        matcher: Optional[PropertyMatcher] = None,
+        matcher: Optional["PropertyMatcher"] = None,
         visited: Optional[Set[Any]] = None,
     ) -> "SerializableData":
         data_id = id(data)


### PR DESCRIPTION
* fixed 2 additional instances

## Description

Finishes fixing using syrupy with Python 3.7

## Related Issues

#586 
