### PR TITLE
refactor: migrate from attrs to dataclasses

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -814,7 +814,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = '>=3.6,<4'
-content-hash = "bf58305cb87ed6f699f9664b5c9885e50dafcd62dca734a306594a6f9d8563cb"
+content-hash = "402b369ef2796217a1a19accbc61fa1713e5a705c4fc07357f9697677410b8ba"
 
 [metadata.files]
 atomicwrites = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -88,7 +88,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.3"
+version = "8.0.4"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
@@ -170,6 +170,14 @@ pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+
+[[package]]
+name = "dataclasses"
+version = "0.8"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "main"
+optional = false
+python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "deprecated"
@@ -410,7 +418,7 @@ testing = ["coverage", "nose"]
 
 [[package]]
 name = "platformdirs"
-version = "2.5.0"
+version = "2.5.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
@@ -806,7 +814,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = '>=3.6,<4'
-content-hash = "9acdc9c9f96f9526accaf3775d39f107a4a9ad69e47820f51502c156bb685aa3"
+content-hash = "bf58305cb87ed6f699f9664b5c9885e50dafcd62dca734a306594a6f9d8563cb"
 
 [metadata.files]
 atomicwrites = [
@@ -907,8 +915,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
-    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 codecov = [
     {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
@@ -1001,6 +1009,10 @@ cryptography = [
     {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903"},
     {file = "cryptography-36.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316"},
     {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
+]
+dataclasses = [
+    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
+    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 deprecated = [
     {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
@@ -1101,8 +1113,8 @@ pkginfo = [
     {file = "pkginfo-1.8.2.tar.gz", hash = "sha256:542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.0-py3-none-any.whl", hash = "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb"},
-    {file = "platformdirs-2.5.0.tar.gz", hash = "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"},
+    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
+    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ python = '>=3.6,<4'
 attrs = '>=18.2.0,<22.0.0'
 colored = '>=1.3.92,<2.0.0'
 pytest = '>=5.1.0,<8.0.0'
+dataclasses = { version = '^0.8.0', python = '>=3.6,<3.7' }
 
 [tool.poetry.group.test.dependencies]
 codecov = '^2.1.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ syrupy = 'syrupy'
 
 [tool.poetry.dependencies]
 python = '>=3.6,<4'
-attrs = '>=18.2.0,<22.0.0'
 colored = '>=1.3.92,<2.0.0'
 pytest = '>=5.1.0,<8.0.0'
 dataclasses = { version = '^0.8.0', python = '>=3.6,<3.7' }

--- a/src/syrupy/data.py
+++ b/src/syrupy/data.py
@@ -1,4 +1,7 @@
-from types import MappingProxyType
+from dataclasses import (
+    dataclass,
+    field,
+)
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -6,8 +9,6 @@ from typing import (
     List,
     Optional,
 )
-
-import attr
 
 from .constants import (
     SNAPSHOT_EMPTY_FOSSIL_KEY,
@@ -18,28 +19,28 @@ if TYPE_CHECKING:
     from .types import SerializedData
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class Snapshot:
-    name: str = attr.ib()
-    data: Optional["SerializedData"] = attr.ib(default=None)
+    name: str
+    data: Optional["SerializedData"] = None
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class SnapshotEmpty(Snapshot):
-    name: str = attr.ib(default=SNAPSHOT_EMPTY_FOSSIL_KEY, init=False)
+    name: str = SNAPSHOT_EMPTY_FOSSIL_KEY
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class SnapshotUnknown(Snapshot):
-    name: str = attr.ib(default=SNAPSHOT_UNKNOWN_FOSSIL_KEY, init=False)
+    name: str = SNAPSHOT_UNKNOWN_FOSSIL_KEY
 
 
-@attr.s
+@dataclass
 class SnapshotFossil:
     """A collection of snapshots at a save location"""
 
-    location: str = attr.ib()
-    _snapshots: Dict[str, "Snapshot"] = attr.ib(factory=dict)
+    location: str
+    _snapshots: Dict[str, "Snapshot"] = field(default_factory=dict)
 
     @property
     def has_snapshots(self) -> bool:
@@ -67,31 +68,31 @@ class SnapshotFossil:
         return iter(self._snapshots.values())
 
 
-SNAPSHOTS_EMPTY = MappingProxyType({SnapshotEmpty().name: SnapshotEmpty()})
-SNAPSHOTS_UNKNOWN = MappingProxyType({SnapshotUnknown().name: SnapshotUnknown()})
-
-
-@attr.s(frozen=True)
+@dataclass
 class SnapshotEmptyFossil(SnapshotFossil):
     """This is a saved fossil that is known to be empty and thus can be removed"""
 
-    _snapshots: Dict[str, "Snapshot"] = attr.ib(default=SNAPSHOTS_EMPTY, init=False)
+    _snapshots: Dict[str, "Snapshot"] = field(
+        default_factory=lambda: {SnapshotEmpty().name: SnapshotEmpty()}
+    )
 
     @property
     def has_snapshots(self) -> bool:
         return False
 
 
-@attr.s(frozen=True)
+@dataclass
 class SnapshotUnknownFossil(SnapshotFossil):
     """This is a saved fossil that is unclaimed by any extension currently in use"""
 
-    _snapshots: Dict[str, "Snapshot"] = attr.ib(default=SNAPSHOTS_UNKNOWN, init=False)
+    _snapshots: Dict[str, "Snapshot"] = field(
+        default_factory=lambda: {SnapshotUnknown().name: SnapshotUnknown()}
+    )
 
 
-@attr.s
+@dataclass
 class SnapshotFossils:
-    _snapshot_fossils: Dict[str, "SnapshotFossil"] = attr.ib(factory=dict)
+    _snapshot_fossils: Dict[str, "SnapshotFossil"] = field(default_factory=dict)
 
     def get(self, location: str) -> Optional["SnapshotFossil"]:
         return self._snapshot_fossils.get(location)
@@ -119,13 +120,13 @@ class SnapshotFossils:
         return key in self._snapshot_fossils
 
 
-@attr.s
+@dataclass
 class DiffedLine:
-    a: str = attr.ib(default=None)
-    b: str = attr.ib(default=None)
-    c: List[str] = attr.ib(factory=list)
-    diff_a: str = attr.ib(default="")
-    diff_b: str = attr.ib(default="")
+    a: Optional[str] = None
+    b: Optional[str] = None
+    c: List[str] = field(default_factory=list)
+    diff_a: str = ""
+    diff_b: str = ""
 
     @property
     def has_snapshot(self) -> bool:

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -273,15 +273,16 @@ class SnapshotReporter(ABC):
     def __diff_lines(self, a: str, b: str) -> Iterator[str]:
         for line in self.__diffed_lines(a, b):
             show_ends = (
-                self.__strip_ends(line.a[1:]) == self.__strip_ends(line.b[1:])
+                self.__strip_ends(line.a[1:] if line.a is not None else "")
+                == self.__strip_ends(line.b[1:] if line.b is not None else "")
                 if line.is_complete
                 else False
             )
-            if line.has_snapshot:
+            if line.has_snapshot and line.a is not None:
                 yield self.__format_line(
                     line.a, line.diff_a, snapshot_style, snapshot_diff_style, show_ends
                 )
-            if line.has_received:
+            if line.has_received and line.b is not None:
                 yield self.__format_line(
                     line.b, line.diff_b, received_style, received_diff_style, show_ends
                 )

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -1,25 +1,28 @@
+from dataclasses import (
+    dataclass,
+    field,
+)
 from pathlib import Path
 from typing import (
     Iterator,
     Optional,
 )
 
-import attr
 import pytest
 
 from syrupy.constants import PYTEST_NODE_SEP
 
 
-@attr.s
+@dataclass
 class PyTestLocation:
-    _node: "pytest.Item" = attr.ib()
-    nodename: Optional[str] = attr.ib(init=False)
-    testname: str = attr.ib(init=False)
-    methodname: str = attr.ib(init=False)
-    modulename: str = attr.ib(init=False)
-    filepath: str = attr.ib(init=False)
+    _node: "pytest.Item"
+    nodename: Optional[str] = field(init=False)
+    testname: str = field(init=False)
+    methodname: str = field(init=False)
+    modulename: str = field(init=False)
+    filepath: str = field(init=False)
 
-    def __attrs_post_init__(self) -> None:
+    def __post_init__(self) -> None:
         self.filepath = getattr(self._node, "fspath")  # noqa: B009
         obj = getattr(self._node, "obj")  # noqa: B009
         self.modulename = obj.__module__

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -1,5 +1,9 @@
 import importlib
 from collections import defaultdict
+from dataclasses import (
+    dataclass,
+    field,
+)
 from gettext import (
     gettext,
     ngettext,
@@ -16,8 +20,6 @@ from typing import (
     List,
     Set,
 )
-
-import attr
 
 from .constants import PYTEST_NODE_SEP
 from .data import (
@@ -43,7 +45,7 @@ if TYPE_CHECKING:
     from .assertion import SnapshotAssertion
 
 
-@attr.s
+@dataclass
 class SnapshotReport:
     """
     This class is responsible for determining the test summary and post execution
@@ -51,21 +53,21 @@ class SnapshotReport:
     information used for removal of unused or orphaned snapshots and fossils.
     """
 
-    base_dir: str = attr.ib()
-    collected_items: Set["pytest.Item"] = attr.ib()
-    selected_items: Dict[str, bool] = attr.ib()
-    options: "argparse.Namespace" = attr.ib()
-    assertions: List["SnapshotAssertion"] = attr.ib()
-    discovered: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
-    created: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
-    failed: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
-    matched: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
-    updated: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
-    used: "SnapshotFossils" = attr.ib(factory=SnapshotFossils)
-    _provided_test_paths: Dict[str, List[str]] = attr.ib(factory=dict)
-    _keyword_expressions: Set["Expression"] = attr.ib(factory=set)
-    _collected_items_by_nodeid: Dict[str, "pytest.Item"] = attr.ib(
-        factory=dict, init=False
+    base_dir: str
+    collected_items: Set["pytest.Item"]
+    selected_items: Dict[str, bool]
+    options: "argparse.Namespace"
+    assertions: List["SnapshotAssertion"]
+    discovered: "SnapshotFossils" = field(default_factory=SnapshotFossils)
+    created: "SnapshotFossils" = field(default_factory=SnapshotFossils)
+    failed: "SnapshotFossils" = field(default_factory=SnapshotFossils)
+    matched: "SnapshotFossils" = field(default_factory=SnapshotFossils)
+    updated: "SnapshotFossils" = field(default_factory=SnapshotFossils)
+    used: "SnapshotFossils" = field(default_factory=SnapshotFossils)
+    _provided_test_paths: Dict[str, List[str]] = field(default_factory=dict)
+    _keyword_expressions: Set["Expression"] = field(default_factory=set)
+    _collected_items_by_nodeid: Dict[str, "pytest.Item"] = field(
+        default_factory=dict, init=False
     )
 
     @property
@@ -80,7 +82,7 @@ class SnapshotReport:
     def include_snapshot_details(self) -> bool:
         return bool(self.options.include_snapshot_details)
 
-    def __attrs_post_init__(self) -> None:
+    def __post_init__(self) -> None:
         self.__parse_invocation_args()
         self._collected_items_by_nodeid = {
             getattr(item, "nodeid"): item for item in self.collected_items  # noqa: B009
@@ -425,7 +427,7 @@ class SnapshotReport:
         )
 
 
-@attr.s(frozen=True)
+@dataclass(frozen=True)
 class Expression:
     """
     Dumbed down version of _pytest.mark.expression.Expression not available in < 6.0
@@ -434,7 +436,7 @@ class Expression:
     module is not public. This only supports inclusion based on simple string matching.
     """
 
-    code: FrozenSet[str] = attr.ib(factory=frozenset)
+    code: FrozenSet[str] = field(default_factory=frozenset)
 
     def evaluate(self, matcher: Callable[[str], bool]) -> bool:
         return any(map(matcher, self.code))


### PR DESCRIPTION
Replace attrs with dataclasses + backport for py3.6. In an effort to reduce dependencies.