### PR TITLE
fix: ignore test_a_suffix snapshots when running test_a

### DIFF
--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -114,4 +114,9 @@ class PyTestLocation:
         return self.__parse(self.snapshot_name) == self.__parse(snapshot_name)
 
     def matches_snapshot_location(self, snapshot_location: str) -> bool:
-        return self.filename in snapshot_location
+        loc = Path(snapshot_location)
+        # "test_file" should match_"test_file.ext" or "test_file/whatever.ext", but not
+        # "test_file_suffix.ext"
+        return self.filename == loc.stem or any(
+            self.filename == parent.name for parent in loc.parents
+        )

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -117,6 +117,4 @@ class PyTestLocation:
         loc = Path(snapshot_location)
         # "test_file" should match_"test_file.ext" or "test_file/whatever.ext", but not
         # "test_file_suffix.ext"
-        return self.filename == loc.stem or any(
-            self.filename == parent.name for parent in loc.parents
-        )
+        return self.filename == loc.stem or self.filename == loc.parent.name

--- a/tests/integration/test_snapshot_similar_names_default.py
+++ b/tests/integration/test_snapshot_similar_names_default.py
@@ -22,16 +22,18 @@ def testcases():
 @pytest.fixture
 def run_testcases(testdir, testcases):
     pyfile_content = "\n\n".join(testcases.values())
-    testdir.makepyfile(test_1=pyfile_content, test_2=pyfile_content)
+    testdir.makepyfile(
+        test_1=pyfile_content, test_2=pyfile_content, test_1_with_suffix=pyfile_content
+    )
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"4 snapshots generated\."))
+    result.stdout.re_match_lines((r"6 snapshots generated\."))
     return testdir, testcases
 
 
 def test_run_all(run_testcases):
     testdir, testcases = run_testcases
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines("4 snapshots passed")
+    result.stdout.re_match_lines("6 snapshots passed")
     assert result.ret == 0
 
 

--- a/tests/integration/test_snapshot_similar_names_default.py
+++ b/tests/integration/test_snapshot_similar_names_default.py
@@ -16,6 +16,12 @@ def testcases():
                 assert snapshot == 'b'
             """
         ),
+        "a_suffix": (
+            """
+            def test_a_suffix(snapshot):
+                assert snapshot == 'a_suffix'
+            """
+        ),
     }
 
 
@@ -26,21 +32,21 @@ def run_testcases(testdir, testcases):
         test_1=pyfile_content, test_2=pyfile_content, test_1_with_suffix=pyfile_content
     )
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"6 snapshots generated\."))
+    result.stdout.re_match_lines((r"9 snapshots generated\."))
     return testdir, testcases
 
 
 def test_run_all(run_testcases):
     testdir, testcases = run_testcases
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines("6 snapshots passed")
+    result.stdout.re_match_lines("9 snapshots passed")
     assert result.ret == 0
 
 
 def test_run_single_file(run_testcases):
     testdir, testcases = run_testcases
     result = testdir.runpytest("-v", "test_1.py")
-    result.stdout.re_match_lines("2 snapshots passed")
+    result.stdout.re_match_lines("3 snapshots passed")
     assert result.ret == 0
 
 
@@ -56,7 +62,7 @@ def test_run_all_but_one(run_testcases):
     result = testdir.runpytest(
         "-v", "--snapshot-details", "test_1.py", "test_2.py::test_a"
     )
-    result.stdout.re_match_lines("3 snapshots passed")
+    result.stdout.re_match_lines("4 snapshots passed")
     assert result.ret == 0
 
 

--- a/tests/integration/test_snapshot_similar_names_file_extension.py
+++ b/tests/integration/test_snapshot_similar_names_file_extension.py
@@ -22,14 +22,16 @@ def testcases():
 @pytest.fixture
 def run_testcases(testdir, testcases):
     pyfile_content = "\n\n".join(testcases.values())
-    testdir.makepyfile(test_1=pyfile_content, test_2=pyfile_content)
+    testdir.makepyfile(
+        test_1=pyfile_content, test_2=pyfile_content, test_1_suffix=pyfile_content
+    )
     result = testdir.runpytest(
         "-v",
         "--snapshot-update",
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines((r"4 snapshots generated\."))
+    result.stdout.re_match_lines((r"6 snapshots generated\."))
     return testdir, testcases
 
 
@@ -40,7 +42,7 @@ def test_run_all(run_testcases):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines("4 snapshots passed")
+    result.stdout.re_match_lines("6 snapshots passed")
     assert result.ret == 0
 
 

--- a/tests/integration/test_snapshot_similar_names_file_extension.py
+++ b/tests/integration/test_snapshot_similar_names_file_extension.py
@@ -16,6 +16,12 @@ def testcases():
                 assert snapshot == b"b"
             """
         ),
+        "a_suffix": (
+            """
+            def test_a_suffix(snapshot):
+                assert snapshot == b"a_suffix"
+            """
+        ),
     }
 
 
@@ -31,7 +37,7 @@ def run_testcases(testdir, testcases):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines((r"6 snapshots generated\."))
+    result.stdout.re_match_lines((r"9 snapshots generated\."))
     return testdir, testcases
 
 
@@ -42,7 +48,7 @@ def test_run_all(run_testcases):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines("6 snapshots passed")
+    result.stdout.re_match_lines("9 snapshots passed")
     assert result.ret == 0
 
 
@@ -54,7 +60,7 @@ def test_run_single_file(run_testcases):
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
         "test_1.py",
     )
-    result.stdout.re_match_lines("2 snapshots passed")
+    result.stdout.re_match_lines("3 snapshots passed")
     assert result.ret == 0
 
 
@@ -80,7 +86,7 @@ def test_run_all_but_one(run_testcases):
         "test_1.py",
         "test_2.py::test_a",
     )
-    result.stdout.re_match_lines("3 snapshots passed")
+    result.stdout.re_match_lines("4 snapshots passed")
     assert result.ret == 0
 
 

--- a/tests/syrupy/test_location.py
+++ b/tests/syrupy/test_location.py
@@ -73,6 +73,8 @@ def test_location_properties(
                 "test_file_extra.snap",
                 "__snapshots__/test_file_extra",
                 "test_file_extra/1.snap",
+                "test_file/extra/1.snap",
+                "__snapshots__/test_file/extra/even/more/1.snap",
             ),
             (
                 "TestClass.method_name",
@@ -91,6 +93,8 @@ def test_location_properties(
                 "test_file_extra.snap",
                 "__snapshots__/test_file_extra",
                 "test_file_extra/1.snap",
+                "test_file/extra/1.snap",
+                "__snapshots__/test_file/extra/even/more/1.snap",
             ),
             (
                 "TestClass.method_name",

--- a/tests/syrupy/test_location.py
+++ b/tests/syrupy/test_location.py
@@ -67,7 +67,13 @@ def test_location_properties(
             "/tests/module/test_file.py::TestClass::method_name",
             "method_name",
             ("test_file.snap", "__snapshots__/test_file", "test_file/1.snap"),
-            ("test.snap", "__others__/test/file.snap"),
+            (
+                "test.snap",
+                "__others__/test/file.snap",
+                "test_file_extra.snap",
+                "__snapshots__/test_file_extra",
+                "test_file_extra/1.snap",
+            ),
             (
                 "TestClass.method_name",
                 "TestClass.method_name[1]",
@@ -79,7 +85,13 @@ def test_location_properties(
             "/tests/module/test_file.py::TestClass::method_name[1]",
             "method_name",
             ("test_file.snap", "__snapshots__/test_file", "test_file/1.snap"),
-            ("test.snap", "__others__/test/file.snap"),
+            (
+                "test.snap",
+                "__others__/test/file.snap",
+                "test_file_extra.snap",
+                "__snapshots__/test_file_extra",
+                "test_file_extra/1.snap",
+            ),
             (
                 "TestClass.method_name",
                 "TestClass.method_name[1]",


### PR DESCRIPTION
## Description

This fixes #596 by making the filename vs. snapshot location matching stricter: instead of allowing a filename of `test_file` to match if it's a substring of the location (e.g. `FOOtest_fileBAR` would match), it now only matches if either of these are true:

- the filename exactly matches, ignoring the extension (e.g. `test_file.ambr` matches, while `test_file_whatever.ambr` does not)
- the parent directory exactly matches (e.g. `.../test_file/foo.bar` matches, but `.../test_file.foo/bar` does not, nor `.../test_file/subdirectory/foo.bar`)

I've added tests for this, as well as expanding the existing ones for #529 to include checking test names that have matching suffices (especially relevant for `tests/integration/test_snapshot_similar_names_file_extension.py`, with the single file snapshots). All three sets of changed tests fail without the change to `location.py`.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #596

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

Thanks for Syrupy!