### PR TITLE
fix: avoid reporting crash for snapshot dir outside pytest dir

### DIFF
--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -299,7 +299,14 @@ class SnapshotReport:
                 for snapshot_fossil in self.unused:
                     filepath = snapshot_fossil.location
                     snapshots = (snapshot.name for snapshot in snapshot_fossil)
-                    path_to_file = str(Path(filepath).relative_to(self.base_dir))
+
+                    try:
+                        path_to_file = str(Path(filepath).relative_to(self.base_dir))
+                    except ValueError:
+                        # this is just used for display, so better to fallback to
+                        # something vaguely reasonable (the full path) than give up
+                        path_to_file = filepath
+
                     unused_snapshots = ", ".join(map(bold, sorted(snapshots)))
                     yield warning_style(gettext(base_message)) + " {} ({})".format(
                         unused_snapshots, path_to_file

--- a/tests/integration/test_snapshot_outside_directory.py
+++ b/tests/integration/test_snapshot_outside_directory.py
@@ -1,0 +1,81 @@
+import pytest
+
+
+@pytest.fixture
+def testcases(testdir, tmp_path):
+    dirname = tmp_path.joinpath("__snapshots__")
+    testdir.makeconftest(
+        f"""
+        import pytest
+
+        from syrupy.extensions.amber import AmberSnapshotExtension
+
+        class CustomSnapshotExtension(AmberSnapshotExtension):
+            @property
+            def _dirname(self):
+                return {str(dirname)!r}
+
+        @pytest.fixture
+        def snapshot(snapshot):
+            return snapshot.use_extension(CustomSnapshotExtension)
+        """
+    )
+    return {
+        "zero": (
+            """
+            def test_do_it(snapshot):
+                pass
+            """
+        ),
+        "one": (
+            """
+            def test_do_it(snapshot):
+                assert snapshot == 'passed1'
+            """
+        ),
+        "two": (
+            """
+            def test_do_it(snapshot):
+                assert snapshot == 'passed1'
+                assert snapshot == 'passed2'
+            """
+        ),
+    }
+
+
+@pytest.fixture
+def generate_snapshots(testdir, testcases):
+    testdir.makepyfile(test_file=testcases["two"])
+    result = testdir.runpytest("-v", "--snapshot-update")
+    return result, testdir, testcases
+
+
+def test_generated_snapshots(generate_snapshots):
+    result = generate_snapshots[0]
+    result.stdout.re_match_lines((r"2 snapshots generated\."))
+    assert "snapshots unused" not in result.stdout.str()
+    assert result.ret == 0
+
+
+def test_unmatched_snapshots(generate_snapshots):
+    _, testdir, testcases = generate_snapshots
+    testdir.makepyfile(test_file=testcases["one"])
+    result = testdir.runpytest("-v")
+    result.stdout.re_match_lines((r"1 snapshot passed. 1 snapshot unused\."))
+    assert result.ret == 1
+
+
+def test_updated_snapshots_partial_delete(generate_snapshots):
+    _, testdir, testcases = generate_snapshots
+    testdir.makepyfile(test_file=testcases["one"])
+    result = testdir.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines(r"1 snapshot passed. 1 unused snapshot deleted\.")
+    assert result.ret == 0
+
+
+def test_updated_snapshots_full_delete(generate_snapshots):
+    _, testdir, testcases = generate_snapshots
+    testdir.makepyfile(test_file=testcases["zero"])
+    result = testdir.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines(r"2 unused snapshots deleted\.")
+    assert result.ret == 0


### PR DESCRIPTION
## Description

This makes the formatting code for the unused snapshots less strict, to stop the detailed reporting (e.g. `--snapshot-details` or `--snapshot-update`) crashing when there's unused snapshots in a directory that's outside the main pytest session root directory.

The display is less good when this comes up, since it's the full path, rather than trimmed to a more relevant section, but it's better than crashing entirely!

## Related Issues

- Closes #620

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

No additional comments.
