### PR TITLE
refactor: write performance improvements, api clarity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,30 @@ Fill in the relevant sections, clearly linking the issue the change is attemping
 
 `debugpy` is installed in local development. A VSCode launch config is provided. Run `inv test -v -d` to enable the debugger (`-d` for debug). It'll then wait for you to attach your VSCode debugging client.
 
+#### Debugging Performance Issues
+
+You can run `inv benchmark` to run the full benchmark suite. Alternatively, write a test file, e.g.:
+
+```py
+# test_performance.py
+import pytest
+import os
+
+SIZE = int(os.environ.get("SIZE", 1000))
+
+@pytest.mark.parametrize("x", range(SIZE))
+def test_performance(x, snapshot):
+    assert x == snapshot
+```
+
+and then run:
+
+```sh
+SIZE=1000 python -m cProfile -s cumtime -m pytest test_performance.py --snapshot-update -s > profile.log
+```
+
+See the cProfile docs for metric sorting options.
+
 ## Styleguides
 
 ### Commit Messages

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -94,7 +94,7 @@ class SnapshotAssertion:
     def __init_extension(
         self, extension_class: Type["AbstractSyrupyExtension"]
     ) -> "AbstractSyrupyExtension":
-        return extension_class(test_location=self.test_location)
+        return extension_class()
 
     @property
     def extension(self) -> "AbstractSyrupyExtension":
@@ -268,6 +268,7 @@ class SnapshotAssertion:
             if not matches and self.update_snapshots:
                 self.session.queue_snapshot_write(
                     extension=self.extension,
+                    test_location=self.test_location,
                     data=serialized_data,
                     index=self.index,
                 )

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -301,7 +301,9 @@ class SnapshotAssertion:
     def _recall_data(self, index: "SnapshotIndex") -> Optional["SerializableData"]:
         try:
             return self.extension.read_snapshot(
-                index=index, session_id=str(id(self.session))
+                test_location=self.extension.test_location,
+                index=index,
+                session_id=str(id(self.session)),
             )
         except SnapshotDoesNotExist:
             return None

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -239,7 +239,9 @@ class SnapshotAssertion:
 
     def _assert(self, data: "SerializableData") -> bool:
         snapshot_location = self.extension.get_location(index=self.index)
-        snapshot_name = self.extension.get_snapshot_name(index=self.index)
+        snapshot_name = self.extension.get_snapshot_name(
+            test_location=self.test_location, index=self.index
+        )
         snapshot_data: Optional["SerializedData"] = None
         serialized_data: Optional["SerializedData"] = None
         matches = False

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -238,7 +238,9 @@ class SnapshotAssertion:
         return self._assert(other)
 
     def _assert(self, data: "SerializableData") -> bool:
-        snapshot_location = self.extension.get_location(index=self.index)
+        snapshot_location = self.extension.get_location(
+            test_location=self.test_location, index=self.index
+        )
         snapshot_name = self.extension.get_snapshot_name(
             test_location=self.test_location, index=self.index
         )
@@ -301,7 +303,7 @@ class SnapshotAssertion:
     def _recall_data(self, index: "SnapshotIndex") -> Optional["SerializableData"]:
         try:
             return self.extension.read_snapshot(
-                test_location=self.extension.test_location,
+                test_location=self.test_location,
                 index=index,
                 session_id=str(id(self.session)),
             )

--- a/src/syrupy/constants.py
+++ b/src/syrupy/constants.py
@@ -1,6 +1,6 @@
 SNAPSHOT_DIRNAME = "__snapshots__"
-SNAPSHOT_EMPTY_FOSSIL_KEY = "empty snapshot fossil"
-SNAPSHOT_UNKNOWN_FOSSIL_KEY = "unknown snapshot fossil"
+SNAPSHOT_EMPTY_FOSSIL_KEY = "empty snapshot collection"
+SNAPSHOT_UNKNOWN_FOSSIL_KEY = "unknown snapshot collection"
 
 EXIT_STATUS_FAIL_UNUSED = 1
 

--- a/src/syrupy/data.py
+++ b/src/syrupy/data.py
@@ -36,7 +36,7 @@ class SnapshotUnknown(Snapshot):
 
 
 @dataclass
-class SnapshotFossil:
+class SnapshotCollection:
     """A collection of snapshots at a save location"""
 
     location: str
@@ -54,8 +54,8 @@ class SnapshotFossil:
         if snapshot.name != SNAPSHOT_EMPTY_FOSSIL_KEY:
             self.remove(SNAPSHOT_EMPTY_FOSSIL_KEY)
 
-    def merge(self, snapshot_fossil: "SnapshotFossil") -> None:
-        for snapshot in snapshot_fossil:
+    def merge(self, snapshot_collection: "SnapshotCollection") -> None:
+        for snapshot in snapshot_collection:
             self.add(snapshot)
 
     def remove(self, snapshot_name: str) -> None:
@@ -69,8 +69,8 @@ class SnapshotFossil:
 
 
 @dataclass
-class SnapshotEmptyFossil(SnapshotFossil):
-    """This is a saved fossil that is known to be empty and thus can be removed"""
+class SnapshotEmptyCollection(SnapshotCollection):
+    """This is a saved collection that is known to be empty and thus can be removed"""
 
     _snapshots: Dict[str, "Snapshot"] = field(
         default_factory=lambda: {SnapshotEmpty().name: SnapshotEmpty()}
@@ -82,8 +82,8 @@ class SnapshotEmptyFossil(SnapshotFossil):
 
 
 @dataclass
-class SnapshotUnknownFossil(SnapshotFossil):
-    """This is a saved fossil that is unclaimed by any extension currently in use"""
+class SnapshotUnknownCollection(SnapshotCollection):
+    """This is a saved collection that is unclaimed by any extension currently in use"""
 
     _snapshots: Dict[str, "Snapshot"] = field(
         default_factory=lambda: {SnapshotUnknown().name: SnapshotUnknown()}
@@ -91,33 +91,33 @@ class SnapshotUnknownFossil(SnapshotFossil):
 
 
 @dataclass
-class SnapshotFossils:
-    _snapshot_fossils: Dict[str, "SnapshotFossil"] = field(default_factory=dict)
+class SnapshotCollections:
+    _snapshot_collections: Dict[str, "SnapshotCollection"] = field(default_factory=dict)
 
-    def get(self, location: str) -> Optional["SnapshotFossil"]:
-        return self._snapshot_fossils.get(location)
+    def get(self, location: str) -> Optional["SnapshotCollection"]:
+        return self._snapshot_collections.get(location)
 
-    def add(self, snapshot_fossil: "SnapshotFossil") -> None:
-        self._snapshot_fossils[snapshot_fossil.location] = snapshot_fossil
+    def add(self, snapshot_collection: "SnapshotCollection") -> None:
+        self._snapshot_collections[snapshot_collection.location] = snapshot_collection
 
-    def update(self, snapshot_fossil: "SnapshotFossil") -> None:
-        snapshot_fossil_to_update = self.get(snapshot_fossil.location)
-        if snapshot_fossil_to_update is None:
-            snapshot_fossil_to_update = SnapshotFossil(
-                location=snapshot_fossil.location
+    def update(self, snapshot_collection: "SnapshotCollection") -> None:
+        snapshot_collection_to_update = self.get(snapshot_collection.location)
+        if snapshot_collection_to_update is None:
+            snapshot_collection_to_update = SnapshotCollection(
+                location=snapshot_collection.location
             )
-            self.add(snapshot_fossil_to_update)
-        snapshot_fossil_to_update.merge(snapshot_fossil)
+            self.add(snapshot_collection_to_update)
+        snapshot_collection_to_update.merge(snapshot_collection)
 
-    def merge(self, snapshot_fossils: "SnapshotFossils") -> None:
-        for snapshot_fossil in snapshot_fossils:
-            self.update(snapshot_fossil)
+    def merge(self, snapshot_collections: "SnapshotCollections") -> None:
+        for snapshot_collection in snapshot_collections:
+            self.update(snapshot_collection)
 
-    def __iter__(self) -> Iterator["SnapshotFossil"]:
-        return iter(self._snapshot_fossils.values())
+    def __iter__(self) -> Iterator["SnapshotCollection"]:
+        return iter(self._snapshot_collections.values())
 
     def __contains__(self, key: str) -> bool:
-        return key in self._snapshot_fossils
+        return key in self._snapshot_collections
 
 
 @dataclass

--- a/src/syrupy/extensions/amber/__init__.py
+++ b/src/syrupy/extensions/amber/__init__.py
@@ -7,7 +7,7 @@ from typing import (
     Set,
 )
 
-from syrupy.data import SnapshotFossil
+from syrupy.data import SnapshotCollection
 from syrupy.extensions.base import AbstractSyrupyExtension
 
 from .serializer import DataSerializer
@@ -33,23 +33,23 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
     def delete_snapshots(
         self, snapshot_location: str, snapshot_names: Set[str]
     ) -> None:
-        snapshot_fossil_to_update = DataSerializer.read_file(snapshot_location)
+        snapshot_collection_to_update = DataSerializer.read_file(snapshot_location)
         for snapshot_name in snapshot_names:
-            snapshot_fossil_to_update.remove(snapshot_name)
+            snapshot_collection_to_update.remove(snapshot_name)
 
-        if snapshot_fossil_to_update.has_snapshots:
-            DataSerializer.write_file(snapshot_fossil_to_update)
+        if snapshot_collection_to_update.has_snapshots:
+            DataSerializer.write_file(snapshot_collection_to_update)
         else:
             Path(snapshot_location).unlink()
 
-    def _read_snapshot_fossil(self, snapshot_location: str) -> "SnapshotFossil":
+    def _read_snapshot_collection(self, snapshot_location: str) -> "SnapshotCollection":
         return DataSerializer.read_file(snapshot_location)
 
     @staticmethod
     @lru_cache()
     def __cacheable_read_snapshot(
         snapshot_location: str, cache_key: str
-    ) -> "SnapshotFossil":
+    ) -> "SnapshotCollection":
         return DataSerializer.read_file(snapshot_location)
 
     def _read_snapshot_data_from_location(
@@ -61,8 +61,10 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
         snapshot = snapshots.get(snapshot_name)
         return snapshot.data if snapshot else None
 
-    def _write_snapshot_fossil(self, *, snapshot_fossil: "SnapshotFossil") -> None:
-        DataSerializer.write_file(snapshot_fossil, merge=True)
+    def _write_snapshot_collection(
+        self, *, snapshot_collection: "SnapshotCollection"
+    ) -> None:
+        DataSerializer.write_file(snapshot_collection, merge=True)
 
 
 __all__ = ["AmberSnapshotExtension", "DataSerializer"]

--- a/src/syrupy/extensions/amber/__init__.py
+++ b/src/syrupy/extensions/amber/__init__.py
@@ -21,6 +21,8 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
     An amber snapshot file stores data in the following format:
     """
 
+    _file_extension = "ambr"
+
     def serialize(self, data: "SerializableData", **kwargs: Any) -> str:
         """
         Returns the serialized form of 'data' to be compared
@@ -39,10 +41,6 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
             DataSerializer.write_file(snapshot_fossil_to_update)
         else:
             Path(snapshot_location).unlink()
-
-    @property
-    def _file_extension(self) -> str:
-        return "ambr"
 
     def _read_snapshot_fossil(self, snapshot_location: str) -> "SnapshotFossil":
         return DataSerializer.read_file(snapshot_location)

--- a/src/syrupy/extensions/amber/__init__.py
+++ b/src/syrupy/extensions/amber/__init__.py
@@ -61,8 +61,9 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
         snapshot = snapshots.get(snapshot_name)
         return snapshot.data if snapshot else None
 
+    @classmethod
     def _write_snapshot_collection(
-        self, *, snapshot_collection: "SnapshotCollection"
+        cls, *, snapshot_collection: "SnapshotCollection"
     ) -> None:
         DataSerializer.write_file(snapshot_collection, merge=True)
 

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -188,7 +188,7 @@ class SnapshotFossilizer(ABC):
                     "Consider adding '{}' to the generated location."
                 ).format(
                     location,
-                    self.test_location.filename,
+                    self.test_location.basename,
                     line_end="\n",
                 )
                 warnings.warn(warning_msg)
@@ -272,7 +272,7 @@ class SnapshotFossilizer(ABC):
 
     def _get_file_basename(self, *, index: "SnapshotIndex") -> str:
         """Returns file basename without extension. Used to create full filepath."""
-        return self.test_location.filename
+        return self.test_location.basename
 
     def __ensure_snapshot_dir(self, *, index: "SnapshotIndex") -> None:
         """

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -110,14 +110,14 @@ class SnapshotCollectionStorage(ABC):
         """Checks if supplied location is valid for this snapshot extension"""
         return location.endswith(self._file_extension)
 
-    def discover_snapshots(self) -> "SnapshotCollections":
+    def discover_snapshots(
+        self, *, test_location: "PyTestLocation"
+    ) -> "SnapshotCollections":
         """
         Returns all snapshot collections in test site
         """
         discovered: "SnapshotCollections" = SnapshotCollections()
-        for filepath in walk_snapshot_dir(
-            self.dirname(test_location=self.test_location)
-        ):
+        for filepath in walk_snapshot_dir(self.dirname(test_location=test_location)):
             if self.is_snapshot_location(location=filepath):
                 snapshot_collection = self._read_snapshot_collection(
                     snapshot_location=filepath

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -100,7 +100,11 @@ class SnapshotCollectionStorage(ABC):
         """Returns full location where snapshot data is stored."""
         basename = self._get_file_basename(index=index)
         fileext = f".{self._file_extension}" if self._file_extension else ""
-        return str(Path(self._dirname).joinpath(f"{basename}{fileext}"))
+        return str(
+            Path(self.dirname(test_location=self.test_location)).joinpath(
+                f"{basename}{fileext}"
+            )
+        )
 
     def is_snapshot_location(self, *, location: str) -> bool:
         """Checks if supplied location is valid for this snapshot extension"""
@@ -111,7 +115,9 @@ class SnapshotCollectionStorage(ABC):
         Returns all snapshot collections in test site
         """
         discovered: "SnapshotCollections" = SnapshotCollections()
-        for filepath in walk_snapshot_dir(self._dirname):
+        for filepath in walk_snapshot_dir(
+            self.dirname(test_location=self.test_location)
+        ):
             if self.is_snapshot_location(location=filepath):
                 snapshot_collection = self._read_snapshot_collection(
                     snapshot_location=filepath
@@ -239,9 +245,8 @@ class SnapshotCollectionStorage(ABC):
         """
         raise NotImplementedError
 
-    @property
-    def _dirname(self) -> str:
-        test_dir = Path(self.test_location.filepath).parent
+    def dirname(self, *, test_location: "PyTestLocation") -> str:
+        test_dir = Path(test_location.filepath).parent
         return str(test_dir.joinpath(SNAPSHOT_DIRNAME))
 
     def _get_file_basename(self, *, index: "SnapshotIndex") -> str:

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -126,16 +126,18 @@ class SnapshotCollectionStorage(ABC):
         return discovered
 
     def read_snapshot(
-        self, *, index: "SnapshotIndex", session_id: str
+        self,
+        *,
+        test_location: "PyTestLocation",
+        index: "SnapshotIndex",
+        session_id: str,
     ) -> "SerializedData":
         """
         This method is _final_, do not override. You can override
         `_read_snapshot_data_from_location` in a subclass to change behaviour.
         """
         snapshot_location = self.get_location(index=index)
-        snapshot_name = self.get_snapshot_name(
-            test_location=self.test_location, index=index
-        )
+        snapshot_name = self.get_snapshot_name(test_location=test_location, index=index)
         snapshot_data = self._read_snapshot_data_from_location(
             snapshot_location=snapshot_location,
             snapshot_name=snapshot_name,

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -82,14 +82,16 @@ class SnapshotFossilizer(ABC):
     def test_location(self) -> "PyTestLocation":
         raise NotImplementedError
 
-    def get_snapshot_name(self, *, index: "SnapshotIndex" = 0) -> str:
+    def get_snapshot_name(
+        self, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
+    ) -> str:
         """Get the snapshot name for the assertion index in a test location"""
         index_suffix = ""
         if isinstance(index, (str,)):
             index_suffix = f"[{index}]"
         elif index:
             index_suffix = f".{index}"
-        return f"{self.test_location.snapshot_name}{index_suffix}"
+        return f"{test_location.snapshot_name}{index_suffix}"
 
     def get_location(self, *, index: "SnapshotIndex") -> str:
         """Returns full location where snapshot data is stored."""
@@ -132,7 +134,9 @@ class SnapshotFossilizer(ABC):
         try:
             self._pre_read(index=index)
             snapshot_location = self.get_location(index=index)
-            snapshot_name = self.get_snapshot_name(index=index)
+            snapshot_name = self.get_snapshot_name(
+                test_location=self.test_location, index=index
+            )
             snapshot_data = self._read_snapshot_data_from_location(
                 snapshot_location=snapshot_location,
                 snapshot_name=snapshot_name,
@@ -171,7 +175,9 @@ class SnapshotFossilizer(ABC):
         locations: DefaultDict[str, List["Snapshot"]] = defaultdict(list)
         for data, index in snapshots:
             location = self.get_location(index=index)
-            snapshot_name = self.get_snapshot_name(index=index)
+            snapshot_name = self.get_snapshot_name(
+                test_location=self.test_location, index=index
+            )
             locations[location].append(Snapshot(name=snapshot_name, data=data))
 
             # Is there a better place to do the pre-writes?

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -77,13 +77,16 @@ class SnapshotSerializer(ABC):
 
 
 class SnapshotFossilizer(ABC):
+    _file_extension = ""
+
     @property
     @abstractmethod
     def test_location(self) -> "PyTestLocation":
         raise NotImplementedError
 
+    @classmethod
     def get_snapshot_name(
-        self, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
+        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
     ) -> str:
         """Get the snapshot name for the assertion index in a test location"""
         index_suffix = ""
@@ -270,11 +273,6 @@ class SnapshotFossilizer(ABC):
     def _dirname(self) -> str:
         test_dir = Path(self.test_location.filepath).parent
         return str(test_dir.joinpath(SNAPSHOT_DIRNAME))
-
-    @property
-    @abstractmethod
-    def _file_extension(self) -> str:
-        raise NotImplementedError
 
     def _get_file_basename(self, *, index: "SnapshotIndex") -> str:
         """Returns file basename without extension. Used to create full filepath."""

--- a/src/syrupy/extensions/image.py
+++ b/src/syrupy/extensions/image.py
@@ -12,15 +12,11 @@ if TYPE_CHECKING:
 
 
 class PNGImageSnapshotExtension(SingleFileSnapshotExtension):
-    @property
-    def _file_extension(self) -> str:
-        return "png"
+    _file_extension = "png"
 
 
 class SVGImageSnapshotExtension(SingleFileSnapshotExtension):
-    @property
-    def _file_extension(self) -> str:
-        return "svg"
+    _file_extension = "svg"
 
     def serialize(self, data: "SerializableData", **kwargs: Any) -> bytes:
         return str(data).encode(TEXT_ENCODING)

--- a/src/syrupy/extensions/json/__init__.py
+++ b/src/syrupy/extensions/json/__init__.py
@@ -31,10 +31,7 @@ if TYPE_CHECKING:
 class JSONSnapshotExtension(SingleFileSnapshotExtension):
     _max_depth: int = 99
     _write_mode = WriteMode.TEXT
-
-    @property
-    def _file_extension(self) -> str:
-        return "json"
+    _file_extension = "json"
 
     @classmethod
     def sort(cls, iterable: Iterable[Any]) -> Iterable[Any]:

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -69,10 +69,11 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     def _get_file_basename(self, *, index: "SnapshotIndex") -> str:
         return self.get_snapshot_name(test_location=self.test_location, index=index)
 
-    @property
-    def _dirname(self) -> str:
-        original_dirname = super(SingleFileSnapshotExtension, self)._dirname
-        return str(Path(original_dirname).joinpath(self.test_location.basename))
+    def dirname(self, *, test_location: "PyTestLocation") -> str:
+        original_dirname = super(SingleFileSnapshotExtension, self).dirname(
+            test_location=test_location
+        )
+        return str(Path(original_dirname).joinpath(test_location.basename))
 
     def _read_snapshot_collection(
         self, *, snapshot_location: str

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -66,8 +66,10 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     ) -> None:
         Path(snapshot_location).unlink()
 
-    def _get_file_basename(self, *, index: "SnapshotIndex") -> str:
-        return self.get_snapshot_name(test_location=self.test_location, index=index)
+    def _get_file_basename(
+        self, *, test_location: "PyTestLocation", index: "SnapshotIndex"
+    ) -> str:
+        return self.get_snapshot_name(test_location=test_location, index=index)
 
     def dirname(self, *, test_location: "PyTestLocation") -> str:
         original_dirname = super(SingleFileSnapshotExtension, self).dirname(

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -13,7 +13,7 @@ from unicodedata import category
 from syrupy.constants import TEXT_ENCODING
 from syrupy.data import (
     Snapshot,
-    SnapshotFossil,
+    SnapshotCollection,
 )
 from syrupy.location import PyTestLocation
 
@@ -74,10 +74,12 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         original_dirname = super(SingleFileSnapshotExtension, self)._dirname
         return str(Path(original_dirname).joinpath(self.test_location.basename))
 
-    def _read_snapshot_fossil(self, *, snapshot_location: str) -> "SnapshotFossil":
-        snapshot_fossil = SnapshotFossil(location=snapshot_location)
-        snapshot_fossil.add(Snapshot(name=Path(snapshot_location).stem))
-        return snapshot_fossil
+    def _read_snapshot_collection(
+        self, *, snapshot_location: str
+    ) -> "SnapshotCollection":
+        snapshot_collection = SnapshotCollection(location=snapshot_location)
+        snapshot_collection.add(Snapshot(name=Path(snapshot_location).stem))
+        return snapshot_collection
 
     def _read_snapshot_data_from_location(
         self, *, snapshot_location: str, snapshot_name: str, session_id: str
@@ -102,8 +104,13 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
             return TEXT_ENCODING
         return None
 
-    def _write_snapshot_fossil(self, *, snapshot_fossil: "SnapshotFossil") -> None:
-        filepath, data = snapshot_fossil.location, next(iter(snapshot_fossil)).data
+    def _write_snapshot_collection(
+        self, *, snapshot_collection: "SnapshotCollection"
+    ) -> None:
+        filepath, data = (
+            snapshot_collection.location,
+            next(iter(snapshot_collection)).data,
+        )
         if not isinstance(data, self._supported_dataclass):
             error_text = gettext(
                 "Can't write non supported data. Expected '{}', got '{}'"

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -40,6 +40,7 @@ class WriteMode(Enum):
 class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     _text_encoding = TEXT_ENCODING
     _write_mode = WriteMode.BINARY
+    _file_extension = "raw"
 
     def serialize(
         self,
@@ -50,11 +51,12 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     ) -> "SerializedData":
         return self._supported_dataclass(data)
 
+    @classmethod
     def get_snapshot_name(
-        self, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
+        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
     ) -> str:
-        return self.__clean_filename(
-            super(SingleFileSnapshotExtension, self).get_snapshot_name(
+        return cls.__clean_filename(
+            AbstractSyrupyExtension.get_snapshot_name(
                 test_location=test_location, index=index
             )
         )
@@ -63,10 +65,6 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         self, *, snapshot_location: str, snapshot_names: Set[str]
     ) -> None:
         Path(snapshot_location).unlink()
-
-    @property
-    def _file_extension(self) -> str:
-        return "raw"
 
     def _get_file_basename(self, *, index: "SnapshotIndex") -> str:
         return self.get_snapshot_name(test_location=self.test_location, index=index)
@@ -118,8 +116,9 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         with open(filepath, f"w{self._write_mode}", encoding=self._write_encoding) as f:
             f.write(data)
 
-    def __clean_filename(self, filename: str) -> str:
-        max_filename_length = 255 - len(self._file_extension or "")
+    @classmethod
+    def __clean_filename(cls, filename: str) -> str:
+        max_filename_length = 255 - len(cls._file_extension or "")
         exclude_chars = '\\/?*:|"<>'
         exclude_categ = ("C",)
         cleaned_filename = "".join(

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -69,7 +69,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     @property
     def _dirname(self) -> str:
         original_dirname = super(SingleFileSnapshotExtension, self)._dirname
-        return str(Path(original_dirname).joinpath(self.test_location.filename))
+        return str(Path(original_dirname).joinpath(self.test_location.basename))
 
     def _read_snapshot_fossil(self, *, snapshot_location: str) -> "SnapshotFossil":
         snapshot_fossil = SnapshotFossil(location=snapshot_location)

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -15,6 +15,7 @@ from syrupy.data import (
     Snapshot,
     SnapshotFossil,
 )
+from syrupy.location import PyTestLocation
 
 from .base import AbstractSyrupyExtension
 
@@ -49,9 +50,13 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     ) -> "SerializedData":
         return self._supported_dataclass(data)
 
-    def get_snapshot_name(self, *, index: "SnapshotIndex" = 0) -> str:
+    def get_snapshot_name(
+        self, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
+    ) -> str:
         return self.__clean_filename(
-            super(SingleFileSnapshotExtension, self).get_snapshot_name(index=index)
+            super(SingleFileSnapshotExtension, self).get_snapshot_name(
+                test_location=test_location, index=index
+            )
         )
 
     def delete_snapshots(
@@ -64,7 +69,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         return "raw"
 
     def _get_file_basename(self, *, index: "SnapshotIndex") -> str:
-        return self.get_snapshot_name(index=index)
+        return self.get_snapshot_name(test_location=self.test_location, index=index)
 
     @property
     def _dirname(self) -> str:

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -66,7 +66,7 @@ class PyTestLocation:
         return str(getattr(self._node, "nodeid"))  # noqa: B009
 
     @property
-    def filename(self) -> str:
+    def basename(self) -> str:
         return Path(self.filepath).stem
 
     @property
@@ -117,4 +117,4 @@ class PyTestLocation:
         loc = Path(snapshot_location)
         # "test_file" should match_"test_file.ext" or "test_file/whatever.ext", but not
         # "test_file_suffix.ext"
-        return self.filename == loc.stem or self.filename == loc.parent.name
+        return self.basename == loc.stem or self.basename == loc.parent.name

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -95,7 +95,11 @@ class SnapshotReport:
             extension_class = assertion.extension.__class__
             if extension_class not in locations_discovered[test_location]:
                 locations_discovered[test_location].add(extension_class)
-                self.discovered.merge(assertion.extension.discover_snapshots())
+                self.discovered.merge(
+                    assertion.extension.discover_snapshots(
+                        test_location=assertion.extension.test_location
+                    )
+                )
 
             for result in assertion.executions.values():
                 snapshot_collection = SnapshotCollection(

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -91,13 +91,13 @@ class SnapshotReport:
         # We only need to discover snapshots once per test file, not once per assertion.
         locations_discovered: DefaultDict[str, Set[Any]] = defaultdict(set)
         for assertion in self.assertions:
-            test_location = assertion.extension.test_location.filepath
+            test_location = assertion.test_location.filepath
             extension_class = assertion.extension.__class__
             if extension_class not in locations_discovered[test_location]:
                 locations_discovered[test_location].add(extension_class)
                 self.discovered.merge(
                     assertion.extension.discover_snapshots(
-                        test_location=assertion.extension.test_location
+                        test_location=assertion.test_location
                     )
                 )
 

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -19,7 +19,7 @@ from typing import (
 import pytest
 
 from .constants import EXIT_STATUS_FAIL_UNUSED
-from .data import SnapshotFossils
+from .data import SnapshotCollections
 from .report import SnapshotReport
 from .types import (
     SerializedData,
@@ -108,8 +108,8 @@ class SnapshotSession:
         if self.report.num_unused:
             if self.update_snapshots:
                 self.remove_unused_snapshots(
-                    unused_snapshot_fossils=self.report.unused,
-                    used_snapshot_fossils=self.report.used,
+                    unused_snapshot_collections=self.report.unused,
+                    used_snapshot_collections=self.report.used,
                 )
             elif not self.warn_unused_snapshots:
                 exitstatus |= EXIT_STATUS_FAIL_UNUSED
@@ -131,25 +131,25 @@ class SnapshotSession:
 
     def remove_unused_snapshots(
         self,
-        unused_snapshot_fossils: "SnapshotFossils",
-        used_snapshot_fossils: "SnapshotFossils",
+        unused_snapshot_collections: "SnapshotCollections",
+        used_snapshot_collections: "SnapshotCollections",
     ) -> None:
         """
-        Remove all unused snapshots using the registed extension for the fossil file
+        Remove all unused snapshots using the registed extension for the collection file
         If there is not registered extension and the location is unused delete the file
         """
-        for unused_snapshot_fossil in unused_snapshot_fossils:
-            snapshot_location = unused_snapshot_fossil.location
+        for unused_snapshot_collection in unused_snapshot_collections:
+            snapshot_location = unused_snapshot_collection.location
 
             extension = self._extensions.get(snapshot_location)
             if extension:
                 extension.delete_snapshots(
                     snapshot_location=snapshot_location,
                     snapshot_names={
-                        snapshot.name for snapshot in unused_snapshot_fossil
+                        snapshot.name for snapshot in unused_snapshot_collection
                     },
                 )
-            elif snapshot_location not in used_snapshot_fossils:
+            elif snapshot_location not in used_snapshot_collections:
                 Path(snapshot_location).unlink()
 
     @staticmethod

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -126,7 +126,9 @@ class SnapshotSession:
             self._locations_discovered[test_location].add(extension_class)
             discovered_extensions = {
                 discovered.location: assertion.extension
-                for discovered in assertion.extension.discover_snapshots()
+                for discovered in assertion.extension.discover_snapshots(
+                    test_location=assertion.extension.test_location
+                )
                 if discovered.has_snapshots
             }
             self._extensions.update(discovered_extensions)

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -65,7 +65,9 @@ class SnapshotSession:
     def flush_snapshot_write_queue(self) -> None:
         for extension, queued_write in self._queued_snapshot_writes.items():
             if queued_write:
-                extension.write_snapshot_batch(snapshots=queued_write)
+                extension.write_snapshot(
+                    test_location=extension.test_location, snapshots=queued_write
+                )
         self._queued_snapshot_writes = {}
 
     @property

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -120,14 +120,14 @@ class SnapshotSession:
     def register_request(self, assertion: "SnapshotAssertion") -> None:
         self._assertions.append(assertion)
 
-        test_location = assertion.extension.test_location.filepath
+        test_location = assertion.test_location.filepath
         extension_class = assertion.extension.__class__
         if extension_class not in self._locations_discovered[test_location]:
             self._locations_discovered[test_location].add(extension_class)
             discovered_extensions = {
                 discovered.location: assertion.extension
                 for discovered in assertion.extension.discover_snapshots(
-                    test_location=assertion.extension.test_location
+                    test_location=assertion.test_location
                 )
                 if discovered.has_snapshots
             }

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -14,9 +14,12 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
 )
 
 import pytest
+
+from syrupy.location import PyTestLocation
 
 from .constants import EXIT_STATUS_FAIL_UNUSED
 from .data import SnapshotCollections
@@ -49,24 +52,33 @@ class SnapshotSession:
     )
 
     _queued_snapshot_writes: Dict[
-        "AbstractSyrupyExtension", List[Tuple["SerializedData", "SnapshotIndex"]]
+        Tuple[Type["AbstractSyrupyExtension"], str],
+        List[Tuple["SerializedData", "PyTestLocation", "SnapshotIndex"]],
     ] = field(default_factory=dict)
 
     def queue_snapshot_write(
         self,
         extension: "AbstractSyrupyExtension",
+        test_location: "PyTestLocation",
         data: "SerializedData",
         index: "SnapshotIndex",
     ) -> None:
-        queue = self._queued_snapshot_writes.get(extension, [])
-        queue.append((data, index))
-        self._queued_snapshot_writes[extension] = queue
+        snapshot_location = extension.get_location(
+            test_location=test_location, index=index
+        )
+        key = (extension.__class__, snapshot_location)
+        queue = self._queued_snapshot_writes.get(key, [])
+        queue.append((data, test_location, index))
+        self._queued_snapshot_writes[key] = queue
 
     def flush_snapshot_write_queue(self) -> None:
-        for extension, queued_write in self._queued_snapshot_writes.items():
+        for (
+            extension_class,
+            snapshot_location,
+        ), queued_write in self._queued_snapshot_writes.items():
             if queued_write:
-                extension.write_snapshot(
-                    test_location=extension.test_location, snapshots=queued_write
+                extension_class.write_snapshot(
+                    snapshot_location=snapshot_location, snapshots=queued_write
                 )
         self._queued_snapshot_writes = {}
 

--- a/tests/examples/test_custom_image_extension.py
+++ b/tests/examples/test_custom_image_extension.py
@@ -14,9 +14,7 @@ from syrupy.extensions.single_file import SingleFileSnapshotExtension
 
 
 class JPEGImageExtension(SingleFileSnapshotExtension):
-    @property
-    def _file_extension(self) -> str:
-        return "jpg"
+    _file_extension = "jpg"
 
 
 @pytest.fixture

--- a/tests/examples/test_custom_snapshot_directory.py
+++ b/tests/examples/test_custom_snapshot_directory.py
@@ -21,7 +21,8 @@ DIFFERENT_DIRECTORY = "__snaps_example__"
 
 
 class DifferentDirectoryExtension(AmberSnapshotExtension):
-    def dirname(self, *, test_location: "PyTestLocation") -> str:
+    @classmethod
+    def dirname(cls, *, test_location: "PyTestLocation") -> str:
         return str(Path(test_location.filepath).parent.joinpath(DIFFERENT_DIRECTORY))
 
 

--- a/tests/examples/test_custom_snapshot_directory.py
+++ b/tests/examples/test_custom_snapshot_directory.py
@@ -15,16 +15,14 @@ from pathlib import Path
 import pytest
 
 from syrupy.extensions.amber import AmberSnapshotExtension
+from syrupy.location import PyTestLocation
 
 DIFFERENT_DIRECTORY = "__snaps_example__"
 
 
 class DifferentDirectoryExtension(AmberSnapshotExtension):
-    @property
-    def _dirname(self) -> str:
-        return str(
-            Path(self.test_location.filepath).parent.joinpath(DIFFERENT_DIRECTORY)
-        )
+    def dirname(self, *, test_location: "PyTestLocation") -> str:
+        return str(Path(test_location.filepath).parent.joinpath(DIFFERENT_DIRECTORY))
 
 
 @pytest.fixture

--- a/tests/examples/test_custom_snapshot_directory_2.py
+++ b/tests/examples/test_custom_snapshot_directory_2.py
@@ -15,14 +15,14 @@ from pathlib import Path
 import pytest
 
 from syrupy.extensions.json import JSONSnapshotExtension
+from syrupy.location import PyTestLocation
 
 
 def create_versioned_fixture(version: int):
     class VersionedJSONExtension(JSONSnapshotExtension):
-        @property
-        def _dirname(self) -> str:
+        def dirname(self, *, test_location: "PyTestLocation") -> str:
             return str(
-                Path(self.test_location.filepath).parent.joinpath(
+                Path(test_location.filepath).parent.joinpath(
                     "__snapshots__", f"v{version}"
                 )
             )

--- a/tests/examples/test_custom_snapshot_directory_2.py
+++ b/tests/examples/test_custom_snapshot_directory_2.py
@@ -20,7 +20,8 @@ from syrupy.location import PyTestLocation
 
 def create_versioned_fixture(version: int):
     class VersionedJSONExtension(JSONSnapshotExtension):
-        def dirname(self, *, test_location: "PyTestLocation") -> str:
+        @classmethod
+        def dirname(cls, *, test_location: "PyTestLocation") -> str:
             return str(
                 Path(test_location.filepath).parent.joinpath(
                     "__snapshots__", f"v{version}"

--- a/tests/examples/test_custom_snapshot_name.py
+++ b/tests/examples/test_custom_snapshot_name.py
@@ -9,10 +9,11 @@ from syrupy.types import SnapshotIndex
 
 
 class CanadianNameExtension(AmberSnapshotExtension):
+    @classmethod
     def get_snapshot_name(
-        self, *, test_location: "PyTestLocation", index: "SnapshotIndex"
+        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex"
     ) -> str:
-        original_name = super(CanadianNameExtension, self).get_snapshot_name(
+        original_name = AmberSnapshotExtension.get_snapshot_name(
             test_location=test_location, index=index
         )
         return f"{original_name}🇨🇦"

--- a/tests/examples/test_custom_snapshot_name.py
+++ b/tests/examples/test_custom_snapshot_name.py
@@ -4,13 +4,16 @@ Example: Custom Snapshot Name
 import pytest
 
 from syrupy.extensions.amber import AmberSnapshotExtension
+from syrupy.location import PyTestLocation
 from syrupy.types import SnapshotIndex
 
 
 class CanadianNameExtension(AmberSnapshotExtension):
-    def get_snapshot_name(self, *, index: "SnapshotIndex") -> str:
+    def get_snapshot_name(
+        self, *, test_location: "PyTestLocation", index: "SnapshotIndex"
+    ) -> str:
         original_name = super(CanadianNameExtension, self).get_snapshot_name(
-            index=index
+            test_location=test_location, index=index
         )
         return f"{original_name}🇨🇦"
 

--- a/tests/integration/test_snapshot_option_update.py
+++ b/tests/integration/test_snapshot_option_update.py
@@ -394,7 +394,7 @@ def test_update_targets_only_selected_module_tests_file_for_removal(run_testcase
     assert not Path("__snapshots__", "test_used.ambr").exists()
 
 
-def test_update_removes_empty_snapshot_fossil_only(run_testcases):
+def test_update_removes_empty_snapshot_collection_only(run_testcases):
     testdir = run_testcases[1]
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
@@ -403,7 +403,8 @@ def test_update_removes_empty_snapshot_fossil_only(run_testcases):
     result.stdout.re_match_lines(
         (
             r"10 snapshots passed\. 1 unused snapshot deleted\.",
-            r"Deleted empty snapshot fossil \(__snapshots__[\\/]empty_snapfile\.ambr\)",
+            r"Deleted empty snapshot collection "
+            r"\(__snapshots__[\\/]empty_snapfile\.ambr\)",
         )
     )
     assert result.ret == 0
@@ -411,7 +412,7 @@ def test_update_removes_empty_snapshot_fossil_only(run_testcases):
     assert Path("__snapshots__", "test_used.ambr").exists()
 
 
-def test_update_removes_hanging_snapshot_fossil_file(run_testcases):
+def test_update_removes_hanging_snapshot_collection_file(run_testcases):
     testdir = run_testcases[1]
     snapfile_used = Path("__snapshots__", "test_used.ambr")
     snapfile_hanging = Path("__snapshots__", "hanging_snapfile.abc")
@@ -421,7 +422,7 @@ def test_update_removes_hanging_snapshot_fossil_file(run_testcases):
     result.stdout.re_match_lines(
         (
             r"10 snapshots passed\. 1 unused snapshot deleted\.",
-            r"Deleted unknown snapshot fossil "
+            r"Deleted unknown snapshot collection "
             r"\(__snapshots__[\\/]hanging_snapfile\.abc\)",
         )
     )

--- a/tests/integration/test_snapshot_outside_directory.py
+++ b/tests/integration/test_snapshot_outside_directory.py
@@ -11,7 +11,8 @@ def testcases(testdir, tmp_path):
         from syrupy.extensions.amber import AmberSnapshotExtension
 
         class CustomSnapshotExtension(AmberSnapshotExtension):
-            def dirname(self, *, test_location):
+            @classmethod
+            def dirname(cls, *, test_location):
                 return {str(dirname)!r}
 
         @pytest.fixture

--- a/tests/integration/test_snapshot_outside_directory.py
+++ b/tests/integration/test_snapshot_outside_directory.py
@@ -11,8 +11,7 @@ def testcases(testdir, tmp_path):
         from syrupy.extensions.amber import AmberSnapshotExtension
 
         class CustomSnapshotExtension(AmberSnapshotExtension):
-            @property
-            def _dirname(self):
+            def dirname(self, *, test_location):
                 return {str(dirname)!r}
 
         @pytest.fixture

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -26,7 +26,8 @@ def testcases_initial(testdir):
                 testname = test_location.testname[::-1]
                 return f"{testname}.{index}"
 
-            def _get_file_basename(self, *, test_location, index):
+            @classmethod
+            def _get_file_basename(cls, *, test_location, index):
                 return test_location.basename[::-1]
 
         @pytest.fixture

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -26,8 +26,8 @@ def testcases_initial(testdir):
                 testname = test_location.testname[::-1]
                 return f"{testname}.{index}"
 
-            def _get_file_basename(self, *, index):
-                return self.test_location.basename[::-1]
+            def _get_file_basename(self, *, test_location, index):
+                return test_location.basename[::-1]
 
         @pytest.fixture
         def snapshot_custom(snapshot):

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -28,7 +28,7 @@ def testcases_initial(testdir):
                 return f"{testname}.{index}"
 
             def _get_file_basename(self, *, index):
-                return self.test_location.filename[::-1]
+                return self.test_location.basename[::-1]
 
         @pytest.fixture
         def snapshot_custom(snapshot):

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -23,7 +23,7 @@ def testcases_initial(testdir):
             def serialize(self, data, **kwargs):
                 return str(data)
 
-            def get_snapshot_name(self, *, index):
+            def get_snapshot_name(self, *, test_location, index):
                 testname = self._test_location.testname[::-1]
                 return f"{testname}.{index}"
 

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -16,15 +16,14 @@ def testcases_initial(testdir):
 
 
         class CustomSnapshotExtension(AmberSnapshotExtension):
-            @property
-            def _file_extension(self):
-                return ""
+            _file_extension = ""
 
             def serialize(self, data, **kwargs):
                 return str(data)
 
-            def get_snapshot_name(self, *, test_location, index):
-                testname = self._test_location.testname[::-1]
+            @classmethod
+            def get_snapshot_name(cls, *, test_location, index):
+                testname = test_location.testname[::-1]
                 return f"{testname}.{index}"
 
             def _get_file_basename(self, *, index):

--- a/tests/syrupy/extensions/test_single_file.py
+++ b/tests/syrupy/extensions/test_single_file.py
@@ -5,7 +5,7 @@ import pytest
 
 from syrupy.data import (
     Snapshot,
-    SnapshotFossil,
+    SnapshotCollection,
 )
 from syrupy.extensions.single_file import (
     SingleFileSnapshotExtension,
@@ -31,15 +31,15 @@ def snapshot_utf8(snapshot):
 
 
 def test_does_not_write_non_binary(testdir, snapshot_single: "SnapshotAssertion"):
-    snapshot_fossil = SnapshotFossil(
-        location=str(Path(testdir.tmpdir).joinpath("snapshot_fossil.raw")),
+    snapshot_collection = SnapshotCollection(
+        location=str(Path(testdir.tmpdir).joinpath("snapshot_collection.raw")),
     )
-    snapshot_fossil.add(Snapshot(name="snapshot_name", data="non binary data"))
+    snapshot_collection.add(Snapshot(name="snapshot_name", data="non binary data"))
     with pytest.raises(TypeError, match="Expected 'bytes', got 'str'"):
-        snapshot_single.extension._write_snapshot_fossil(
-            snapshot_fossil=snapshot_fossil
+        snapshot_single.extension._write_snapshot_collection(
+            snapshot_collection=snapshot_collection
         )
-    assert not Path(snapshot_fossil.location).exists()
+    assert not Path(snapshot_collection.location).exists()
 
 
 class TestClass:

--- a/tests/syrupy/test_location.py
+++ b/tests/syrupy/test_location.py
@@ -54,7 +54,7 @@ def test_location_properties(
 ):
     location = PyTestLocation(mock_pytest_item(node_id, method_name))
     assert location.classname == expected_classname
-    assert location.filename == expected_filename
+    assert location.basename == expected_filename
     assert location.snapshot_name == expected_snapshotname
 
 


### PR DESCRIPTION
## Description

This PR fixes the write perf regression in syrupy v4 prerelease. As part of the refactoring necessary to fix write perf for batch writes, I ended up simplifying some of the APIs. There are a number of breaking changes, from:

- renaming SnapshotFossil to SnapshotCollection
- changing properties to methods or variables
- adding test_location as a param to a bunch of methods
- changing instance methods to classmethods (ultimately to make write_snapshot static)
- removal of pre/post read/write hooks (if someone has a valid use case, we can add it back -- it semantically changed when we shifted to batch writes anyway)