### PR TITLE
fix: improve pytest-xdist compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,14 @@ If you have decided not to use Syrupy for your project after giving us a try, we
 
 Benchmarks are automatically published to https://tophat.github.io/syrupy/dev/bench/.
 
+## Known Limitations
+
+- `pytest-xdist` support only partially exists. There is no issue when it comes to reads however when you attempt to run `pytest --snapshot-update`, if running with more than 1 process, the ability to detect unused snapshots is disabled. See [#535](https://github.com/tophat/syrupy/issues/535) for more information.
+- _Extremely_ large snapshots may fail due to a known Python core library bug. See [#577](https://github.com/tophat/syrupy/issues/577) and [cpython #65452](https://github.com/python/cpython/issues/65452).
+
+_We welcome contributions to patch these known limitations._
+
+
 ## Contributing
 
 Feel free to open a PR or GitHub issue. Contributions welcome!

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -199,10 +199,7 @@ class SnapshotCollectionStorage(ABC):
                 warnings.warn(warning_msg)
 
         # Ensures the folder path for the snapshot file exists.
-        try:
-            Path(snapshot_location).parent.mkdir(parents=True)
-        except FileExistsError:
-            pass
+        Path(snapshot_location).parent.mkdir(parents=True, exist_ok=True)
 
         cls._write_snapshot_collection(snapshot_collection=snapshot_collection)
 

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -4,6 +4,7 @@ from dataclasses import (
     dataclass,
     field,
 )
+from functools import cached_property
 from gettext import (
     gettext,
     ngettext,
@@ -53,11 +54,14 @@ class SnapshotReport:
     information used for removal of unused or orphaned snapshots and collections.
     """
 
+    # Initial arguments to the report
     base_dir: str
     collected_items: Set["pytest.Item"]
     selected_items: Dict[str, bool]
     options: "argparse.Namespace"
     assertions: List["SnapshotAssertion"]
+
+    # All of these are derived from the initial arguments and via walking the filesystem
     discovered: "SnapshotCollections" = field(default_factory=SnapshotCollections)
     created: "SnapshotCollections" = field(default_factory=SnapshotCollections)
     failed: "SnapshotCollections" = field(default_factory=SnapshotCollections)
@@ -66,9 +70,6 @@ class SnapshotReport:
     used: "SnapshotCollections" = field(default_factory=SnapshotCollections)
     _provided_test_paths: Dict[str, List[str]] = field(default_factory=dict)
     _keyword_expressions: Set["Expression"] = field(default_factory=set)
-    _collected_items_by_nodeid: Dict[str, "pytest.Item"] = field(
-        default_factory=dict, init=False
-    )
 
     @property
     def update_snapshots(self) -> bool:
@@ -82,11 +83,14 @@ class SnapshotReport:
     def include_snapshot_details(self) -> bool:
         return bool(self.options.include_snapshot_details)
 
-    def __post_init__(self) -> None:
-        self.__parse_invocation_args()
-        self._collected_items_by_nodeid = {
+    @cached_property
+    def _collected_items_by_nodeid(self) -> Dict[str, "pytest.Item"]:
+        return {
             getattr(item, "nodeid"): item for item in self.collected_items  # noqa: B009
         }
+
+    def __post_init__(self) -> None:
+        self.__parse_invocation_args()
 
         # We only need to discover snapshots once per test file, not once per assertion.
         locations_discovered: DefaultDict[str, Set[Any]] = defaultdict(set)

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -14,6 +14,16 @@ from .constants import SNAPSHOT_DIRNAME
 from .exceptions import FailedToLoadModuleMember
 
 
+def is_xdist_worker() -> bool:
+    worker_name = os.getenv("PYTEST_XDIST_WORKER")
+    return bool(worker_name and worker_name != "master")
+
+
+def is_xdist_controller() -> bool:
+    worker_count = os.getenv("PYTEST_XDIST_WORKER_COUNT")
+    return bool(worker_count and int(worker_count) > 0 and not is_xdist_worker())
+
+
 def in_snapshot_dir(path: Path) -> bool:
     return SNAPSHOT_DIRNAME in path.parts
 


### PR DESCRIPTION
NOTE: When pytest-xdist is detected, we do not remove unused snapshots, since that requires coordination between the workers and the controller. A disclaimer has been added to the README and TODO comments added to the source code to help solve this problem at some point.

Related: #535 
