### PR TITLE
remove dependency on pytest legacy path

### DIFF
--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -28,7 +28,7 @@ class PyTestLocation:
         self.__attrs_post_init_def__()
 
     def __attrs_post_init_def__(self) -> None:
-        self.filepath = getattr(self._node, "fspath")  # noqa: B009
+        self.filepath = getattr(self._node, "path")  # noqa: B009
         obj = getattr(self._node, "obj")  # noqa: B009
         self.modulename = obj.__module__
         self.methodname = obj.__name__

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -77,7 +77,7 @@ class SnapshotSession:
     def finish(self) -> int:
         exitstatus = 0
         self.report = SnapshotReport(
-            base_dir=self.pytest_session.config.rootdir,
+            base_dir=self.pytest_session.config.rootpath,
             collected_items=self._collected_items,
             selected_items=self._selected_items,
             assertions=self._assertions,


### PR DESCRIPTION
## Description

Just ran `pytest -p no:legacypath` and fixed the two exceptions that came up. Verified it also runs w/ legacy paths allowed.

## Related Issues

- Closes #677, syrupy dependent on pytest legacy paths

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [x ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

No additional comments.
