### PR TITLE
Fix bootstrap script run in non-Bash shells

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Based on conventions from https://github.com/github/scripts-to-rule-them-all
 # script/bootstrap: Resolve all dependencies that the application requires to
 # run.


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

The script uses some Bash-specific syntax. Previously, if the user's shell defaults to e.g. Zsh, the script would run and report syntax errors.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).
