### PR TITLE
fix: defer snapshot default extension import

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -41,11 +41,6 @@ def __import_extension(value: Optional[str]) -> Any:
         raise argparse.ArgumentTypeError(e)
 
 
-def __default_extension_option(value: Optional[str]) -> Any:
-    __import_extension(value)
-    return value
-
-
 def pytest_addoption(parser: Any) -> None:
     """
     Exposes snapshot plugin configuration to pytest.
@@ -78,7 +73,6 @@ def pytest_addoption(parser: Any) -> None:
     # all pytest options to be serializable.
     group.addoption(
         "--snapshot-default-extension",
-        type=__default_extension_option,
         default=None,
         dest="default_extension",
         help="Specify the default snapshot extension",

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -48,11 +48,14 @@ def import_module_member(path: str) -> Any:
             )
         )
     try:
-        return getattr(import_module(module_name), module_member_name)
+        module = import_module(module_name)
     except ModuleNotFoundError:
         raise FailedToLoadModuleMember(
             gettext("Module '{}' does not exist.").format(module_name)
         )
+
+    try:
+        return getattr(module, module_member_name)
     except AttributeError:
         raise FailedToLoadModuleMember(
             gettext("Member '{}' not found in module '{}'.").format(

--- a/tests/integration/test_snapshot_option_extension.py
+++ b/tests/integration/test_snapshot_option_extension.py
@@ -37,12 +37,7 @@ def test_snapshot_default_extension_option_failure(testfile):
         "--snapshot-default-extension",
         "syrupy.extensions.amber.DoesNotExistExtension",
     )
-    result.stderr.re_match_lines(
-        (
-            r".*error: argument --snapshot-default-extension"
-            r": Member 'DoesNotExistExtension' not found.*",
-        )
-    )
+    result.stdout.re_match_lines((r".*: Member 'DoesNotExistExtension' not found.*",))
     assert not Path(
         testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
     ).exists()

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -3,7 +3,14 @@ from pathlib import Path
 
 import pytest
 
+import syrupy
+
 SUBDIR = "subdir_not_on_default_path"
+
+
+@pytest.fixture(autouse=True)
+def cache_clear():
+    syrupy.__import_extension.cache_clear()
 
 
 @pytest.fixture

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -6,6 +6,7 @@ import pytest
 @pytest.fixture
 def testfile(testdir):
     testdir.makepyfile(
+        __init__="",
         extension_file=(
             """
             import syrupy
@@ -26,10 +27,16 @@ def testfile(testdir):
 
 
 def test_snapshot_default_extension_option_success(testfile):
+    testfile.makeini(
+        f"""
+        [pytest]
+        pythonpath =
+            {testfile.tmpdir}
+    """
+    )
+
     result = testfile.runpytest(
         "-v",
-        "--pythonpath",
-        testfile.tmpdir,
         "--snapshot-update",
         "--snapshot-default-extension",
         "extension_file.MySingleFileExtension",
@@ -63,10 +70,16 @@ def test_snapshot_default_extension_option_module_not_found(testfile):
 
 
 def test_snapshot_default_extension_option_failure(testfile):
+    testfile.makeini(
+        f"""
+        [pytest]
+        pythonpath =
+            {testfile.tmpdir}
+    """
+    )
+
     result = testfile.runpytest(
         "-v",
-        "--pythonpath",
-        testfile.tmpdir,
         "--snapshot-update",
         "--snapshot-default-extension",
         "extension_file.DoesNotExistExtension",

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -15,19 +15,20 @@ def cache_clear():
 
 @pytest.fixture
 def testfile(testdir):
-    subdir = testdir.mkdir(SUBDIR)
+    subdir = testdir.mkpydir(SUBDIR)
 
     Path(
         subdir,
         "extension_file.py",
     ).write_text(
-        textwrap.dedent(
+        data=textwrap.dedent(
             """
             from syrupy.extensions.single_file import SingleFileSnapshotExtension
             class MySingleFileExtension(SingleFileSnapshotExtension):
                 pass
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     testdir.makepyfile(

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -52,7 +52,7 @@ def test_snapshot_default_extension_option_module_not_found(testfile):
         "-v",
         "--snapshot-update",
         "--snapshot-default-extension",
-        "extension_file.MySingleFileExtensions",
+        "extension_file.MySingleFileExtension",
     )
     result.stdout.re_match_lines((r".*: Module 'extension_file' does not exist.*",))
     assert not Path(

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -14,8 +14,8 @@ def cache_clear():
 
 
 @pytest.fixture
-def testfile(testdir):
-    subdir = testdir.mkpydir(SUBDIR)
+def testfile(pytester):
+    subdir = pytester.mkpydir(SUBDIR)
 
     Path(
         subdir,
@@ -31,7 +31,7 @@ def testfile(testdir):
         encoding="utf-8",
     )
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         test_file=(
             """
             def test_default(snapshot):
@@ -40,7 +40,7 @@ def testfile(testdir):
         )
     )
 
-    return testdir
+    return pytester
 
 
 def test_snapshot_default_extension_option_success(testfile):
@@ -48,7 +48,7 @@ def test_snapshot_default_extension_option_success(testfile):
         f"""
         [pytest]
         pythonpath =
-            {Path(testfile.tmpdir, SUBDIR)}
+            {Path(testfile.path, SUBDIR)}
     """
     )
 
@@ -60,7 +60,7 @@ def test_snapshot_default_extension_option_success(testfile):
     )
     result.stdout.re_match_lines((r"1 snapshot generated\."))
     assert Path(
-        testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
+        testfile.path, "__snapshots__", "test_file", "test_default.raw"
     ).exists()
     assert not result.ret
 
@@ -74,7 +74,7 @@ def test_snapshot_default_extension_option_module_not_found(testfile):
     )
     result.stdout.re_match_lines((r".*: Module 'extension_file' does not exist.*",))
     assert not Path(
-        testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
+        testfile.path, "__snapshots__", "test_file", "test_default.raw"
     ).exists()
     assert result.ret
 
@@ -84,7 +84,7 @@ def test_snapshot_default_extension_option_failure(testfile):
         f"""
         [pytest]
         pythonpath =
-            {Path(testfile.tmpdir, SUBDIR)}
+            {Path(testfile.path, SUBDIR)}
     """
     )
 
@@ -96,6 +96,6 @@ def test_snapshot_default_extension_option_failure(testfile):
     )
     result.stdout.re_match_lines((r".*: Member 'DoesNotExistExtension' not found.*",))
     assert not Path(
-        testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
+        testfile.path, "__snapshots__", "test_file", "test_default.raw"
     ).exists()
     assert result.ret

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def testfile(testdir):
+    testdir.makepyfile(
+        extension_file=(
+            """
+            import syrupy
+            class MySingleFileExtension(
+                syrupy.extensions.single_file.SingleFileSnapshotExtension
+            ):
+                pass
+            """
+        ),
+        test_file=(
+            """
+            def test_default(snapshot):
+                assert b"default extension serializer" == snapshot
+            """
+        ),
+    )
+    return testdir
+
+
+def test_snapshot_default_extension_option_success(testfile):
+    result = testfile.runpytest(
+        "-v",
+        "--pythonpath",
+        testfile.tmpdir,
+        "--snapshot-update",
+        "--snapshot-default-extension",
+        "extension_file.MySingleFileExtension",
+    )
+    assert not result.errlines
+    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    assert Path(
+        testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
+    ).exists()
+    assert not result.ret
+
+
+def test_snapshot_default_extension_option_module_not_found(testfile):
+    result = testfile.runpytest(
+        "-v",
+        "--snapshot-update",
+        "--snapshot-default-extension",
+        "extension_file.MySingleFileExtensions",
+    )
+    assert not result.outlines
+    result.stderr.re_match_lines(
+        (
+            r".*error: argument --snapshot-default-extension"
+            r": Module 'extension_file' does not exist.*",
+        )
+    )
+    assert not Path(
+        testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
+    ).exists()
+    assert result.ret
+
+
+def test_snapshot_default_extension_option_failure(testfile):
+    result = testfile.runpytest(
+        "-v",
+        "--pythonpath",
+        testfile.tmpdir,
+        "--snapshot-update",
+        "--snapshot-default-extension",
+        "extension_file.DoesNotExistExtension",
+    )
+    assert not result.outlines
+    result.stderr.re_match_lines(
+        (
+            r".*error: argument --snapshot-default-extension"
+            r": Member 'DoesNotExistExtension' not found.*",
+        )
+    )
+    assert not Path(
+        testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
+    ).exists()
+    assert result.ret

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -1,27 +1,37 @@
+import textwrap
 from pathlib import Path
 
 import pytest
 
+SUBDIR = "subdir_not_on_default_path"
+
 
 @pytest.fixture
 def testfile(testdir):
-    testdir.makepyfile(
-        extension_file=(
+    subdir = testdir.mkdir(SUBDIR)
+
+    Path(
+        subdir,
+        "extension_file.py",
+    ).write_text(
+        textwrap.dedent(
             """
-            import syrupy
-            class MySingleFileExtension(
-                syrupy.extensions.single_file.SingleFileSnapshotExtension
-            ):
+            from syrupy.extensions.single_file import SingleFileSnapshotExtension
+            class MySingleFileExtension(SingleFileSnapshotExtension):
                 pass
             """
-        ),
+        )
+    )
+
+    testdir.makepyfile(
         test_file=(
             """
             def test_default(snapshot):
                 assert b"default extension serializer" == snapshot
             """
-        ),
+        )
     )
+
     return testdir
 
 
@@ -30,7 +40,7 @@ def test_snapshot_default_extension_option_success(testfile):
         f"""
         [pytest]
         pythonpath =
-            {testfile.tmpdir}
+            {Path(testfile.tmpdir, SUBDIR)}
     """
     )
 
@@ -66,7 +76,7 @@ def test_snapshot_default_extension_option_failure(testfile):
         f"""
         [pytest]
         pythonpath =
-            {testfile.tmpdir}
+            {Path(testfile.tmpdir, SUBDIR)}
     """
     )
 

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -6,7 +6,6 @@ import pytest
 @pytest.fixture
 def testfile(testdir):
     testdir.makepyfile(
-        __init__="",
         extension_file=(
             """
             import syrupy

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -41,7 +41,6 @@ def test_snapshot_default_extension_option_success(testfile):
         "--snapshot-default-extension",
         "extension_file.MySingleFileExtension",
     )
-    assert not result.errlines
     result.stdout.re_match_lines((r"1 snapshot generated\."))
     assert Path(
         testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
@@ -56,13 +55,7 @@ def test_snapshot_default_extension_option_module_not_found(testfile):
         "--snapshot-default-extension",
         "extension_file.MySingleFileExtensions",
     )
-    assert not result.outlines
-    result.stderr.re_match_lines(
-        (
-            r".*error: argument --snapshot-default-extension"
-            r": Module 'extension_file' does not exist.*",
-        )
-    )
+    result.stdout.re_match_lines((r".*: Module 'extension_file' does not exist.*",))
     assert not Path(
         testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
     ).exists()
@@ -84,13 +77,7 @@ def test_snapshot_default_extension_option_failure(testfile):
         "--snapshot-default-extension",
         "extension_file.DoesNotExistExtension",
     )
-    assert not result.outlines
-    result.stderr.re_match_lines(
-        (
-            r".*error: argument --snapshot-default-extension"
-            r": Member 'DoesNotExistExtension' not found.*",
-        )
-    )
+    result.stdout.re_match_lines((r".*: Member 'DoesNotExistExtension' not found.*",))
     assert not Path(
         testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
     ).exists()

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -48,7 +48,7 @@ def test_snapshot_default_extension_option_success(testfile):
         f"""
         [pytest]
         pythonpath =
-            {Path(testfile.path, SUBDIR)}
+            {Path(testfile.path, SUBDIR).as_posix()}
     """
     )
 
@@ -84,7 +84,7 @@ def test_snapshot_default_extension_option_failure(testfile):
         f"""
         [pytest]
         pythonpath =
-            {Path(testfile.path, SUBDIR)}
+            {Path(testfile.path, SUBDIR).as_posix()}
     """
     )
 


### PR DESCRIPTION
## Description

Fixes unable to use pytest's `pythonpath` option with this project's `--snapshot-default-extension` option. 

Does cause extension import errors to raise later than CLI argument parsing, and therefore emit on stdout, instead of stderr.

Also fix shadowing `AttributeError` during import.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #719 
  - Relevant quote: 
    > The unexpected "does not exist" error is raised during pytest's plugin discovery's command line parsing. This suggests to me two solutions.
    >
    > * Rearchitecting pytest to honor --pythonpath before its plugin discovery (sounds difficult to change the upstream project)
    > * Defer *this* project's module import until *after* pytest honors --pythonpath (sounds easier)
    > 
    > I'm looking into the latter.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
