### PR TITLE
fix: incorrect marking of TestClass.test_method as unused, close #717

### DIFF
--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -82,9 +82,10 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
     ) -> "SnapshotCollection":
         file_ext_len = len(self._file_extension) + 1 if self._file_extension else 0
         filename_wo_ext = snapshot_location[:-file_ext_len]
+        basename = Path(filename_wo_ext).parts[-1]
 
         snapshot_collection = SnapshotCollection(location=snapshot_location)
-        snapshot_collection.add(Snapshot(name=Path(filename_wo_ext).stem))
+        snapshot_collection.add(Snapshot(name=basename))
         return snapshot_collection
 
     def _read_snapshot_data_from_location(

--- a/tests/integration/test_single_file_multiple_extensions.py
+++ b/tests/integration/test_single_file_multiple_extensions.py
@@ -38,3 +38,39 @@ def test_multiple_file_extensions(testdir):
     result.stdout.re_match_lines((r"1 snapshot passed\."))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
+
+
+def test_class_style(testdir):
+    """
+    Regression test for https://github.com/tophat/syrupy/issues/717
+    """
+
+    testcase = """
+    import pytest
+    from syrupy.extensions.json import JSONSnapshotExtension
+
+    @pytest.fixture
+    def snapshot(snapshot):
+        return snapshot.use_extension(JSONSnapshotExtension)
+
+    class TestFoo:
+        def test_foo(self, snapshot):
+            assert { 'key': 'value' } == snapshot
+    """
+
+    test_file: Path = testdir.makepyfile(test_file=testcase)
+
+    result = testdir.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    assert "deleted" not in result.stdout.str()
+    assert result.ret == 0
+
+    snapshot_file = (
+        Path(test_file).parent / "__snapshots__" / "test_file" / "TestFoo.test_foo.json"
+    )
+    assert snapshot_file.exists()
+
+    result = testdir.runpytest("-v")
+    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    assert "snapshots unused" not in result.stdout.str()
+    assert result.ret == 0


### PR DESCRIPTION
## Description

Fixes regression from https://github.com/tophat/syrupy/pull/710

Closes #717, closes #752
