### PR TITLE
fix: hide empty snapshot report

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -173,9 +173,14 @@ def pytest_terminal_summary(
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_terminal_summary
     """
     with __terminal_color(config):
-        terminalreporter.write_sep("-", gettext("snapshot report summary"))
+        is_printing_report = False
         for line in terminalreporter.config._syrupy.report.lines:
-            terminalreporter.write_line(line)
+            has_report_line = bool(line.strip())
+            if has_report_line and not is_printing_report:
+                terminalreporter.write_sep("-", gettext("snapshot report summary"))
+                is_printing_report = True
+            if is_printing_report:
+                terminalreporter.write_line(line)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Waits until there's a report to be printed before adding to the terminal output

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #534, Hide empty snapshot report

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

Manual testing 👇🏾 

### After

```sh
$ inv test -t 'notestsmatchesthis'
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspaces/syrupy
configfile: pyproject.toml
plugins: syrupy-4.0.4, xdist-3.3.1, benchmark-4.0.0
collected 250 items / 250 deselected / 0 selected                                                                                                                                       

================================================================================ 250 deselected in 0.20s ================================================================================
```

```sh
$ inv test -t 'json'
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspaces/syrupy
configfile: pyproject.toml
plugins: syrupy-4.0.4, xdist-3.3.1, benchmark-4.0.0
collected 250 items / 184 deselected / 66 selected                                                                                                                                      

tests/syrupy/extensions/json/test_json_filters.py ......                                                                                                                          [  9%]
tests/syrupy/extensions/json/test_json_matchers.py .                                                                                                                              [ 10%]
tests/syrupy/extensions/json/test_json_serializer.py ...........................................................                                                                  [100%]

-------------------------------------------------------------------------------- snapshot report summary --------------------------------------------------------------------------------
79 snapshots passed.
========================================================================== 66 passed, 184 deselected in 0.36s ===========================================================================
```

### Before

```sh
$ inv test -t 'notestsmatchesthis'
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspaces/syrupy
configfile: pyproject.toml
plugins: syrupy-4.0.4, xdist-3.3.1, benchmark-4.0.0
collected 250 items / 250 deselected / 0 selected                                                                                                                                       

-------------------------------------------------------------------------------- snapshot report summary --------------------------------------------------------------------------------

================================================================================ 250 deselected in 0.19s ================================================================================
```
