### PR TITLE
fix: improve reporting around xfailed snapshots, close #736

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -45,6 +45,7 @@ class AssertionResult:
     updated: bool
     success: bool
     exception: Optional[Exception]
+    test_location: "PyTestLocation"
 
     @property
     def final_data(self) -> Optional["SerializedData"]:
@@ -303,14 +304,15 @@ class SnapshotAssertion:
             snapshot_updated = matches is False and assertion_success
             self._execution_name_index[self.index] = self._executions
             self._execution_results[self._executions] = AssertionResult(
+                asserted_data=serialized_data,
+                created=snapshot_created,
+                exception=assertion_exception,
+                recalled_data=snapshot_data,
                 snapshot_location=snapshot_location,
                 snapshot_name=snapshot_name,
-                recalled_data=snapshot_data,
-                asserted_data=serialized_data,
                 success=assertion_success,
-                created=snapshot_created,
+                test_location=self.test_location,
                 updated=snapshot_updated,
-                exception=assertion_exception,
             )
             self._executions += 1
             self._post_assert()

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -15,7 +15,7 @@ from syrupy.constants import PYTEST_NODE_SEP
 
 @dataclass
 class PyTestLocation:
-    _node: "pytest.Item"
+    item: "pytest.Item"
     nodename: Optional[str] = field(init=False)
     testname: str = field(init=False)
     methodname: str = field(init=False)
@@ -28,16 +28,16 @@ class PyTestLocation:
         self.__attrs_post_init_def__()
 
     def __attrs_post_init_def__(self) -> None:
-        node_path: Path = getattr(self._node, "path")  # noqa: B009
+        node_path: Path = getattr(self.item, "path")  # noqa: B009
         self.filepath = str(node_path.absolute())
-        obj = getattr(self._node, "obj")  # noqa: B009
+        obj = getattr(self.item, "obj")  # noqa: B009
         self.modulename = obj.__module__
         self.methodname = obj.__name__
-        self.nodename = getattr(self._node, "name", None)
+        self.nodename = getattr(self.item, "name", None)
         self.testname = self.nodename or self.methodname
 
     def __attrs_post_init_doc__(self) -> None:
-        doctest = getattr(self._node, "dtest")  # noqa: B009
+        doctest = getattr(self.item, "dtest")  # noqa: B009
         self.filepath = doctest.filename
         test_relfile, test_node = self.nodeid.split(PYTEST_NODE_SEP)
         test_relpath = Path(test_relfile)
@@ -64,7 +64,7 @@ class PyTestLocation:
         :raises: `AttributeError` if node has no node id
         :return: test node id
         """
-        return str(getattr(self._node, "nodeid"))  # noqa: B009
+        return str(getattr(self.item, "nodeid"))  # noqa: B009
 
     @property
     def basename(self) -> str:
@@ -78,7 +78,7 @@ class PyTestLocation:
 
     @property
     def is_doctest(self) -> bool:
-        return self.__is_doctest(self._node)
+        return self.__is_doctest(self.item)
 
     def __is_doctest(self, node: "pytest.Item") -> bool:
         return hasattr(node, "dtest")

--- a/tests/integration/test_xfail.py
+++ b/tests/integration/test_xfail.py
@@ -1,0 +1,54 @@
+def test_no_failure_printed_if_all_failures_xfailed(testdir):
+    testdir.makepyfile(
+        test_file=(
+            """
+        import pytest
+
+        @pytest.mark.xfail(reason="Failure expected.")
+        def test_a(snapshot):
+            assert snapshot == 'does-not-exist'
+        """
+        )
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.no_re_match_line((r".*snapshot failed*"))
+    assert result.ret == 0
+
+
+def test_failures_printed_if_only_some_failures_xfailed(testdir):
+    testdir.makepyfile(
+        test_file=(
+            """
+        import pytest
+
+        @pytest.mark.xfail(reason="Failure expected.")
+        def test_a(snapshot):
+            assert snapshot == 'does-not-exist'
+
+        def test_b(snapshot):
+            assert snapshot == 'other'
+        """
+        )
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.re_match_lines((r".*1 snapshot failed*"))
+    result.stdout.re_match_lines((r".*1 snapshot xfailed*"))
+    assert result.ret == 1
+
+
+def test_failure_printed_if_xfail_does_not_run(testdir):
+    testdir.makepyfile(
+        test_file=(
+            """
+        import pytest
+
+        @pytest.mark.xfail(False, reason="Failure expected.")
+        def test_a(snapshot):
+            assert snapshot == 'does-not-exist'
+        """
+        )
+    )
+    result = testdir.runpytest("-v")
+    result.stdout.re_match_lines((r".*1 snapshot failed*"))
+    result.stdout.no_re_match_line((r".*1 snapshot xfailed*"))
+    assert result.ret == 1

--- a/tests/syrupy/extensions/amber/test_amber_snapshot_diff.py
+++ b/tests/syrupy/extensions/amber/test_amber_snapshot_diff.py
@@ -51,9 +51,9 @@ def test_snapshot_diff_id(snapshot):
     assert dictCase3 == snapshot(name="case3", diff="large snapshot")
 
 
+@pytest.mark.xfail(reason="Asserting snapshot does not exist")
 def test_snapshot_no_diff_raises_exception(snapshot):
     my_dict = {
         "field_0": "value_0",
     }
-    with pytest.raises(AssertionError, match="SnapshotDoesNotExist"):
-        assert my_dict == snapshot(diff="does not exist index")
+    assert my_dict == snapshot(diff="does not exist index")


### PR DESCRIPTION
## Description

Not handling xpasses here (contributions welcome). If the number of xfails == failures, we omit the failure summary entirely. Otherwise, we print the number of xfailures.

![image](https://github.com/tophat/syrupy/assets/1297096/b35c3668-6901-4f0d-88d8-cf7356fe84f8)
