### PR TITLE
fix: preserve Falsy values in assertion diff function

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -206,7 +206,9 @@ class SnapshotAssertion:
             # Rotate to place exception with message at first line
             return lines[-1:] + lines[:-1]
         snapshot_data = assertion_result.recalled_data
-        serialized_data = assertion_result.asserted_data or ""
+        if assertion_result.asserted_data is None:
+            assertion_result.asserted_data = ""
+        serialized_data = assertion_result.asserted_data
         diff: List[str] = []
         if snapshot_data is None:
             diff.append(
@@ -215,7 +217,9 @@ class SnapshotAssertion:
                 )
             )
         if not assertion_result.success:
-            diff.extend(self.extension.diff_lines(serialized_data, snapshot_data or ""))
+            if snapshot_data is None:
+                snapshot_data = ""
+            diff.extend(self.extension.diff_lines(serialized_data, snapshot_data))
         return diff
 
     def __with_prop(self, prop_name: str, prop_value: Any) -> None:

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -206,7 +206,11 @@ class SnapshotAssertion:
             # Rotate to place exception with message at first line
             return lines[-1:] + lines[:-1]
         snapshot_data = assertion_result.recalled_data
-        serialized_data = assertion_result.asserted_data if assertion_result.asserted_data is not None else ""
+        serialized_data = (
+            assertion_result.asserted_data
+            if assertion_result.asserted_data is not None
+            else ""
+        )
         diff: List[str] = []
         if snapshot_data is None:
             diff.append(

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -206,9 +206,7 @@ class SnapshotAssertion:
             # Rotate to place exception with message at first line
             return lines[-1:] + lines[:-1]
         snapshot_data = assertion_result.recalled_data
-        if assertion_result.asserted_data is None:
-            assertion_result.asserted_data = ""
-        serialized_data = assertion_result.asserted_data
+        serialized_data = assertion_result.asserted_data if assertion_result.asserted_data is not None else ""
         diff: List[str] = []
         if snapshot_data is None:
             diff.append(
@@ -217,8 +215,7 @@ class SnapshotAssertion:
                 )
             )
         if not assertion_result.success:
-            if snapshot_data is None:
-                snapshot_data = ""
+            snapshot_data = snapshot_data if snapshot_data is not None else ""
             diff.extend(self.extension.diff_lines(serialized_data, snapshot_data))
         return diff
 


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

This PR does a None check here-https://github.com/tophat/syrupy/blob/f4bc8453466af2cfa75cdda1d50d67bc8c4396c3/src/syrupy/assertion.py#L209

This helps me extend the `SingleFileSnapshotExtension` to save snapshots as HDF files. Please see issue https://github.com/tophat/syrupy/issues/786 to  know more.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

Closes https://github.com/tophat/syrupy/issues/786

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
