### PR TITLE
feat(serializer): add support for FunctionType serialization

### DIFF
--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -1,7 +1,9 @@
 import collections
+import inspect
 import os
 from collections import OrderedDict
 from types import (
+    FunctionType,
     GeneratorType,
     MappingProxyType,
 )
@@ -257,6 +259,8 @@ class AmberDataSerializer:
             serialize_method = cls.serialize_namedtuple
         elif isinstance(data, (list, tuple, GeneratorType)):
             serialize_method = cls.serialize_iterable
+        elif isinstance(data, FunctionType):
+            serialize_method = cls.serialize_function
         return serialize_method(**serialize_kwargs)
 
     @classmethod
@@ -335,6 +339,14 @@ class AmberDataSerializer:
             separator=": ",
             serialize_key=True,
             **kwargs,
+        )
+
+    @classmethod
+    def serialize_function(
+        cls, data: FunctionType, *, depth: int = 0, **kwargs: Any
+    ) -> str:
+        return cls.__serialize_plain(
+            data=f"{data.__qualname__}{str(inspect.signature(data))}", depth=depth
         )
 
     @classmethod

--- a/src/syrupy/extensions/json/__init__.py
+++ b/src/syrupy/extensions/json/__init__.py
@@ -1,7 +1,11 @@
 import datetime
+import inspect
 import json
 from collections import OrderedDict
-from types import GeneratorType
+from types import (
+    FunctionType,
+    GeneratorType,
+)
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -132,6 +136,12 @@ class JSONSnapshotExtension(SingleFileSnapshotExtension):
 
         if isinstance(data, (datetime.datetime,)):
             return data.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
+
+        if isinstance(data, FunctionType):
+            return (
+                f"<{FunctionType.__name__} "
+                f"'{data.__qualname__}{str(inspect.signature(data))}'>"
+            )
 
         if data.__class__.__repr__ != object.__repr__:
             return repr(data)

--- a/src/syrupy/extensions/json/__init__.py
+++ b/src/syrupy/extensions/json/__init__.py
@@ -140,7 +140,7 @@ class JSONSnapshotExtension(SingleFileSnapshotExtension):
         if isinstance(data, FunctionType):
             return (
                 f"<{FunctionType.__name__} "
-                f"'{data.__qualname__}{str(inspect.signature(data))}'>"
+                f"{data.__qualname__}{str(inspect.signature(data))}>"
             )
 
         if data.__class__.__repr__ != object.__repr__:

--- a/tests/syrupy/extensions/amber/__snapshots__/test_amber_serializer.ambr
+++ b/tests/syrupy/extensions/amber/__snapshots__/test_amber_serializer.ambr
@@ -217,6 +217,12 @@
 # name: test_empty_snapshot.1
   ''
 # ---
+# name: test_function_in_file
+  "function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> str"
+# ---
+# name: test_function_local
+  "test_function_local.<locals>.local_function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> int"
+# ---
 # name: test_list[actual0]
   list([
   ])

--- a/tests/syrupy/extensions/amber/test_amber_serializer.py
+++ b/tests/syrupy/extensions/amber/test_amber_serializer.py
@@ -233,3 +233,22 @@ def test_ordered_dict(snapshot):
 def test_many_sorted(snapshot):
     for i in range(25):
         assert i == snapshot
+
+
+def function_to_test(
+    var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
+) -> str:
+    return "2"
+
+
+def test_function_in_file(snapshot):
+    assert snapshot() == function_to_test
+
+
+def test_function_local(snapshot):
+    def local_function_to_test(
+        var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
+    ) -> int:
+        return 1
+
+    assert snapshot() == local_function_to_test

--- a/tests/syrupy/extensions/amber/test_amber_serializer.py
+++ b/tests/syrupy/extensions/amber/test_amber_serializer.py
@@ -236,7 +236,7 @@ def test_many_sorted(snapshot):
 
 
 def function_to_test(
-    var1, var2="test_val", var3: str="test_val2", *, kwvar1, kwvar2: str="some_val"
+    var1, var2="test_val", var3: str="test_val2", *, kwvar1, kwvar2="some_val"
 ) -> str:
     return "2"
 

--- a/tests/syrupy/extensions/amber/test_amber_serializer.py
+++ b/tests/syrupy/extensions/amber/test_amber_serializer.py
@@ -236,7 +236,7 @@ def test_many_sorted(snapshot):
 
 
 def function_to_test(
-    var1, var2="test_val", var3: str="test_val2", *, kwvar1, kwvar2="some_val"
+    var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
 ) -> str:
     return "2"
 
@@ -247,7 +247,7 @@ def test_function_in_file(snapshot):
 
 def test_function_local(snapshot):
     def local_function_to_test(
-        var1, var2="test_val", var3: str="test_val2", *, kwvar1, kwvar2="some_val"
+        var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
     ) -> int:
         return 1
 

--- a/tests/syrupy/extensions/amber/test_amber_serializer.py
+++ b/tests/syrupy/extensions/amber/test_amber_serializer.py
@@ -236,19 +236,19 @@ def test_many_sorted(snapshot):
 
 
 def function_to_test(
-    var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
+    var1, var2="test_val", var3: str="test_val2", *, kwvar1, kwvar2: str="some_val"
 ) -> str:
     return "2"
 
 
 def test_function_in_file(snapshot):
-    assert snapshot() == function_to_test
+    assert snapshot == function_to_test
 
 
 def test_function_local(snapshot):
     def local_function_to_test(
-        var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
+        var1, var2="test_val", var3: str="test_val2", *, kwvar1, kwvar2="some_val"
     ) -> int:
         return 1
 
-    assert snapshot() == local_function_to_test
+    assert snapshot == local_function_to_test

--- a/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_in_file.json
+++ b/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_in_file.json
@@ -1,0 +1,1 @@
+"<function 'function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> str'>"

--- a/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_in_file.json
+++ b/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_in_file.json
@@ -1,1 +1,1 @@
-"<function 'function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> str'>"
+"<function function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> str>"

--- a/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_local.json
+++ b/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_local.json
@@ -1,1 +1,1 @@
-"<function 'test_function_local.<locals>.local_function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> int'>"
+"<function test_function_local.<locals>.local_function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> int>"

--- a/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_local.json
+++ b/tests/syrupy/extensions/json/__snapshots__/test_json_serializer/test_function_local.json
@@ -1,0 +1,1 @@
+"<function 'test_function_local.<locals>.local_function_to_test(var1, var2='test_val', var3: str = 'test_val2', *, kwvar1, kwvar2='some_val') -> int'>"

--- a/tests/syrupy/extensions/json/test_json_serializer.py
+++ b/tests/syrupy/extensions/json/test_json_serializer.py
@@ -232,3 +232,22 @@ def test_ordered_dict(snapshot_json):
     d["b"] = 0
     d["a"] = OrderedDict(b=True, a=False)
     assert snapshot_json == d
+
+
+def function_to_test(
+    var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
+) -> str:
+    return "2"
+
+
+def test_function_in_file(snapshot_json):
+    assert snapshot_json() == function_to_test
+
+
+def test_function_local(snapshot_json):
+    def local_function_to_test(
+        var1, var2="test_val", var3: str = "test_val2", *, kwvar1, kwvar2="some_val"
+    ) -> int:
+        return 1
+
+    assert snapshot_json() == local_function_to_test

--- a/tests/syrupy/extensions/json/test_json_serializer.py
+++ b/tests/syrupy/extensions/json/test_json_serializer.py
@@ -241,7 +241,7 @@ def function_to_test(
 
 
 def test_function_in_file(snapshot_json):
-    assert snapshot_json() == function_to_test
+    assert snapshot_json == function_to_test
 
 
 def test_function_local(snapshot_json):
@@ -250,4 +250,4 @@ def test_function_local(snapshot_json):
     ) -> int:
         return 1
 
-    assert snapshot_json() == local_function_to_test
+    assert snapshot_json == local_function_to_test


### PR DESCRIPTION
* add FunctionType serialization in amber and json extensions
* add tests

## Description

add FunctionType serialization in amber and json extensions

## Related Issues

- Closes #808 , More generic serialization of function types

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

I used inspect as I didn't want to re-invent the wheel. Is this satisfactory?

Also of minor concern - this changes the format of existing FunctionType serialization. I don't think this realistically causes a problem as the prior serialization would change every time it ran anyway.
